### PR TITLE
set ssb-config appname via $ssb_appname envvar.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,7 @@ var http = require('http')
 var fs   = require('fs')
 
 var windows    = require('./lib/windows')
-var config     = require('ssb-config')
+var config     = require('ssb-config/inject')(process.env.ssb_appname)
 var ssbKeys    = require('ssb-keys')
 var createSbot = require('scuttlebot')
   .use(require('scuttlebot/plugins/master'))


### PR DESCRIPTION
this makes it easy to test user onboarding.
```
cb patchwork
ssb_appname=foo electron .
```
and the database will be created under `~.{ssb_appname}`.
