### PR TITLE
npm install ssb-patchwork; patchwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,40 +14,26 @@ That's our informal barrier to entry right now, since we're not prepared for lot
 Patchwork embeds [Scuttlebot](https://github.com/ssbc/scuttlebot), so if you're running Patchwork, you don't need to run another scuttlebot server.
 
 
-## Running Patchwork
+## Install
 
-Current install steps are:
-
-```
-# ubuntu
-apt-get install automake libtool
-# osx
-brew install automake libtool
+``` bash
+npm install patchwork -g
 ```
 
-Also, you'll need to use iojs@2.
-The easiest way to get this is [nvm](https://github.com/creationix/nvm).
+## Run
 
-```
-nvm install iojs-v2.5.0
-```
-
-Then, install the software:
-
-```
-git clone https://github.com/ssbc/patchwork.git
-cd patchwork
-npm install
-npm start
+``` bash
+patchwork
 ```
 
-And then join a pub server.
+If it's your first time running patchwork,
+follow the on screen instructions to start a new identity
+and join a pub server.
 
 
-## Development & App-building : 
+## Development & App-building :
 
-
-**Dependencies**
+to build for windows:
 
 ```
 # Linux dependencies

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,8 @@
+#! /usr/bin/env node
+
+require('child_process')
+  .spawn(
+    require('path').join(__dirname, 'node_modules/.bin/electron'),
+    ['.'],
+    {stdio: 'inherit', cwd: __dirname}
+  )

--- a/bin.sh
+++ b/bin.sh
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-./node_modules/.bin/electron .

--- a/bin.sh
+++ b/bin.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+./node_modules/.bin/electron .

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   },
   "bin": {
     "patchwork": "./bin.sh",
-    "sbot": "./node_module/scuttlebot/sbot.js"
+    "sbot": "./node_modules/scuttlebot/sbot.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssb-patchwork",
   "version": "1.0.2",
-  "description": "",
+  "description": "safe secure sharing",
   "main": "app/index.js",
   "scripts": {
     "start": "electron .",
@@ -17,14 +17,14 @@
     "build:nix": "electron-packager ./ patchwork --out=dist/linux --platform=linux --arch=x64 --ignore=node_modules/electron* --version=0.28.3 --icon=assets/osx/patchwork.icns",
     "pack": "npm run pack:osx && npm run pack:win",
     "pack:osx": "electron-builder \"dist/osx/Patchwork.app\" --platform=osx --out=\"dist/osx\" --config=packager.json",
-    "pack:win": "electron-builder \"dist/win/Patchwork-win32\" --platform=win --out=\"dist/win\" --config=packager.json"
+    "pack:win": "electron-builder \"dist/win/Patchwork-win32\" --platform=win --out=\"dist/win\" --config=packager.json",
+    "prepublish": "npm run build:ui"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "?",
   "devDependencies": {
     "electron-builder": "^2.0.0",
     "electron-packager": "^4.1.3",
-    "electron-prebuilt": "^0.33.7",
     "less": "~1.7.5",
     "osenv": "~0.1.0",
     "rimraf": "~2.2.8",
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "blob-to-buffer": "^1.2.3",
+    "electron-prebuilt": "^0.33.7",
     "emoji-named-characters": "^1.0.1",
     "hyperscript": "~1.4.6",
     "mime-types": "^2.1.3",
@@ -62,5 +63,9 @@
     "ssb-ref": "~2.2.0",
     "stream-to-pull-stream": "^1.6.1",
     "suggest-box": "~1.1.6"
+  },
+  "bin": {
+    "patchwork": "./bin.sh",
+    "sbot": "./node_module/scuttlebot/sbot.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "suggest-box": "~1.1.6"
   },
   "bin": {
-    "patchwork": "./bin.sh",
-    "sbot": "./node_modules/scuttlebot/sbot.js"
+    "patchwork": "./bin.js"
   }
 }


### PR DESCRIPTION
installing and running patchwork is now simpler than ever.
mainly updated deps (chloride) and added `bin.js`. also updated documentation to refect simpler dependencies.