### PR TITLE
Improved composer

### DIFF
--- a/ui/com/composer.jsx
+++ b/ui/com/composer.jsx
@@ -102,8 +102,15 @@ class ComposerTextarea extends React.Component {
     textarea.style.height = 0
     textarea.style.height = textarea.scrollHeight + 'px'
   }
+  onKeyDown(e) {
+    if (e.keyCode == 13 && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      e.stopPropagation()
+      this.props.onSubmit()
+    }
+  }
   render() {
-    return <textarea ref="textarea" {...this.props} onKeyUp={this.onKeyUp.bind(this)} />
+    return <textarea ref="textarea" {...this.props} onKeyUp={this.onKeyUp.bind(this)} onKeyDown={this.onKeyDown.bind(this)} />
   }
 }
 
@@ -281,7 +288,7 @@ export default class Composer extends React.Component {
       <ComposerAudience isPublic={this.state.isPublic} isReadOnly={this.state.isReply} {...this.audienceHandlers} />
       <ComposerRecps isPublic={this.state.isPublic} isReadOnly={this.state.isReply} recps={this.state.recps} onAdd={this.onAddRecp.bind(this)} onRemove={this.onRemoveRecp.bind(this)} />
       <div className="composer-content">
-        <ComposerTextarea value={this.state.text} onChange={this.onChangeText.bind(this)} placeholder={!this.state.isReply ? `Write a message...` : `Write a reply...`} />
+        <ComposerTextarea value={this.state.text} onChange={this.onChangeText.bind(this)} onSubmit={this.onSend.bind(this)} placeholder={!this.state.isReply ? `Write a message...` : `Write a reply...`} />
       </div>
       <div className="composer-ctrls flex">
         <div className="flex-fill">

--- a/ui/com/composer.jsx
+++ b/ui/com/composer.jsx
@@ -96,8 +96,14 @@ class ComposerTextarea extends React.Component {
     suggestBox(textarea, app.suggestOptions)
     textarea.addEventListener('suggestselect', this.props.onChange)
   }
+  onKeyUp() {
+    const textarea = this.refs.textarea
+    textarea.style.overflow = 'hidden'
+    textarea.style.height = 0
+    textarea.style.height = textarea.scrollHeight + 'px'
+  }
   render() {
-    return <textarea ref="textarea" {...this.props} />
+    return <textarea ref="textarea" {...this.props} onKeyUp={this.onKeyUp.bind(this)} />
   }
 }
 

--- a/ui/com/composer.jsx
+++ b/ui/com/composer.jsx
@@ -333,9 +333,15 @@ export default class Composer extends React.Component {
         this.setState({ isSending: false })
         if (err) modals.error('Error While Publishing', err, 'This error occurred while trying to publish a new post.')
         else {
+          // remove draft and reset form
           this.setState({ text: '' })
+          if (this.state.currentDraft)
+            this.onDeleteDraft(this.state.currentDraft)
+
           // mark read (include the thread root because the api will automatically mark the root unread on new reply)
           app.ssb.patchwork.markRead((this.threadRoot) ? [this.threadRoot, msg.key] : msg.key)
+
+          // call handler
           if (this.props.onSend)
             this.props.onSend(msg)
         }

--- a/ui/less/com/composer.less
+++ b/ui/less/com/composer.less
@@ -83,6 +83,49 @@
       }
     }
   }
+  .composer-drafts {
+    background: #f5f5f5;
+    position: relative;
+
+    &:before {
+      content: 'drafts';
+      position: absolute;
+      top: -12px;
+      right: 50%;
+      color: gray;
+    }
+    & > div {
+      display: flex;   
+      height: 40px;
+      color: gray;
+      font-weight: 300;
+      border-top: 1px solid #ddd;
+      div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: pre;
+        &:first-child {
+          margin: 10px;
+          flex: 1;
+        }
+        &:last-child {
+          padding: 10px 16px;
+          &.delete:hover {
+            background: red;
+            color: white;
+          }
+        }
+      }
+      &:hover {
+        cursor: pointer;
+        background: #fafafa;
+      }
+      &.selected {
+        color: #555;
+        background: #fefefe;
+      }
+    }
+  }
   .warning {
     color: @dark-red3;
     margin: 5px 0;

--- a/ui/less/com/composer.less
+++ b/ui/less/com/composer.less
@@ -50,9 +50,9 @@
     textarea {
       display: block;
       width: 496px;
-      resize: vertical;
+      resize: none;
       border: 1px solid #eee;
-      min-height: 140px;
+      min-height: 50px;
       padding: 10px;
       margin: 5px;
 

--- a/ui/less/com/composer.less
+++ b/ui/less/com/composer.less
@@ -50,7 +50,7 @@
     textarea {
       display: block;
       width: 496px;
-      resize: none;
+      resize: vertical;
       border: 1px solid #eee;
       min-height: 140px;
       padding: 10px;

--- a/ui/less/com/fab.less
+++ b/ui/less/com/fab.less
@@ -1,7 +1,7 @@
 .fab {
   position: fixed;
-  top: 10px;
-  right: 75px;
+  bottom: 20px;
+  right: 25px;
   z-index: 1000;
 
   a.primary {


### PR DESCRIPTION
![screen shot 2015-11-11 at 2 30 25 pm](https://cloud.githubusercontent.com/assets/1270099/11102245/eea2a358-8880-11e5-8719-5bbc13b63c42.png)
![screen shot 2015-11-11 at 2 30 30 pm](https://cloud.githubusercontent.com/assets/1270099/11102244/ee923d4c-8880-11e5-8a92-6fdde0a42fe0.png)

Adds drafts (to non-replies), automatic resizing of the textarea to fit text, and cmd/ctrl+enter to submit

Drafts still need a little work, but they're serviceable for now. The composer automatically saves them to the browser window's localstorage on every edit, so you can leave the composer and come back with no issue.