### PR TITLE
ui: threads now render 'missing message' cards when a reply refers to a branch that's not found

### DIFF
--- a/ui/com/msg-view/card.jsx
+++ b/ui/com/msg-view/card.jsx
@@ -161,7 +161,7 @@ export default class Card extends React.Component {
         { expanded ?
           <span
             ><br/><br/>
-            {'This post is by somebody outside of your network, and hasn\'t been downloaded. Some of the messages in this thread may reply to it.'}
+            {'This post is by somebody outside of your network, and hasn\'t been downloaded. Some of the messages in this thread may reference it.'}
           </span> :
           ' This post could not be loaded.' }
       </div>

--- a/ui/less/com/msg-view/card.less
+++ b/ui/less/com/msg-view/card.less
@@ -127,6 +127,24 @@
   }
 }
 
+.msg-view.card-missing-post {
+  max-width: 600px;
+  margin: 20px auto;
+  padding-right: 130px;
+
+  div {
+    .elevation-card;
+    margin-left: 77px;
+    background: #fafafa;
+    padding: 20px;
+    font-weight: 300;
+    color: #666;
+  }
+  &.expanded div {
+    background: #fff;
+  }
+}
+
 .msg-view.card-muted {
   display: flex;
   max-width: 600px;


### PR DESCRIPTION
https://github.com/ssbc/patchwork/issues/88

When a message references a `branch` that's not in the `relatedMessages` results, this code will render the following:

![screen shot 2015-11-12 at 12 57 32 pm](https://cloud.githubusercontent.com/assets/1270099/11128100/4e3574aa-893d-11e5-808d-08b5f27d58b4.png)

Clicking on the blue text expands into a longer explanation:

![screen shot 2015-11-12 at 12 57 39 pm](https://cloud.githubusercontent.com/assets/1270099/11128101/4e35deb8-893d-11e5-8aa1-f461e36425f9.png)
