### PR TITLE
add time-ago in words for times > 1 min

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-infinite": "^0.5.10",
     "react-modal": "^0.6.0",
     "react-router": "^1.0.0-rc1",
+    "react-timeago": "^2.2.1",
     "scuttlebot": "~7.3.3",
     "ssb-config": "^1.0.3",
     "ssb-keys": "^4.0.3",

--- a/ui/com/index.jsx
+++ b/ui/com/index.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom'
 import { Link } from 'react-router'
 import Modal from 'react-modal'
 import xtend from 'xtend'
+import TimeAgo from 'react-timeago'
 import app from '../lib/app'
 import social from '../lib/social-graph'
 import u from '../lib/util'
@@ -64,6 +65,15 @@ export class UserBtn extends React.Component {
 export class NiceDate extends React.Component {
   render() {
     return <span>{u.niceDate(this.props.ts)}</span>
+  }
+}
+
+export class LastSeen extends React.Component {
+  render() {
+    const isRecent = new Date - this.props.ts < 60000
+    return <span>
+      {isRecent ? 'moments ago' : <TimeAgo date={this.props.ts} />}
+    </span>
   }
 }
 

--- a/ui/views/sync.jsx
+++ b/ui/views/sync.jsx
@@ -5,7 +5,7 @@ import ip from 'ip'
 import app from '../lib/app'
 import u from '../lib/util'
 import social from '../lib/social-graph'
-import { UserLink, NiceDate, VerticalFilledContainer } from '../com/index'
+import { UserLink, NiceDate, LastSeen, VerticalFilledContainer } from '../com/index'
 import { PromptModalBtn, InviteModalBtn } from '../com/modals'
 
 function peerId (peer) {
@@ -69,15 +69,13 @@ class PeerStatus extends React.Component {
     let lastConnected = ''
     if (!peer.connected) {
       if (peer.time && peer.time.connect) {
-        lastConnected = <div className="light">Last seen at <NiceDate ts={peer.time.connect} /></div>
+        lastConnected = <div className="light"><LastSeen ts={peer.time.connect} /></div>
       } else {
         failureClass = ' failure'
-        lastConnected = ''//<i className="fa fa-close connection-status" title="last attempted connection: " />
+        lastConnected = ''
       }
     }
 
-        // { isMember ? <span className={'known-peer-symbol connection-status'+connectionClass}></span> : 
-        //              // <i className={'unknown-peer-symbol fa fa-question-circle connection-status'+connectionClass} /> }
     const isMember = social.follows(peer.key, app.user.id)
     return <div className={'peer flex'+failureClass}>
       <div className='flex-fill'>


### PR DESCRIPTION
**Purpose** : making connection times easier to read. 

![selection_102](https://cloud.githubusercontent.com/assets/2665886/11320583/f55b427a-9101-11e5-825a-8bb2231205bb.png)

Behaviour is to say "moments ago" instead of reporting every second change, which is quite distracting. 

I've dropped the "Last seen" prefix. Interested know if others find it confusing.
open to language changes