### PR TITLE
enable detection of local peers

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -17,6 +17,7 @@ var createSbot = require('scuttlebot')
   .use(require('scuttlebot/plugins/block'))
   .use(require('scuttlebot/plugins/logging'))
   .use(require('scuttlebot/plugins/private'))
+  .use(require('scuttlebot/plugins/local'))
   .use(require('../api'))
 
 config.keys = ssbKeys.loadOrCreateSync(path.join(config.path, 'secret'))


### PR DESCRIPTION
the local plugin must be activated to detect local peers.