### PR TITLE
Maintain scroll position on back-navigations

### DIFF
--- a/ui/com/help/welcome.jsx
+++ b/ui/com/help/welcome.jsx
@@ -1,5 +1,6 @@
 'use babel'
 import React from 'react'
+import { Link } from 'react-router'
 import { InviteModalBtn } from '../modals'
 
 export default class WelcomeHelp extends React.Component {
@@ -23,7 +24,7 @@ export default class WelcomeHelp extends React.Component {
         <h2>Step 3: <img className="emoji" src="./img/emoji/metal.png" width="20" height="20"/></h2>
         <p>You can send <strong>Public Posts</strong> and <strong>Secret Messages</strong> using the blue button on the top right of your feed.</p>
       </div>
-      <a className="card centered btn selected highlighted" style={{display: 'block', textAlign: 'center'}} href='#/'><h3>Got it.</h3></a>
+      <Link className="card centered btn selected highlighted" style={{display: 'block', textAlign: 'center'}} to='/'><h3>Got it.</h3></Link>
     </div>
   }
 }

--- a/ui/com/index.jsx
+++ b/ui/com/index.jsx
@@ -91,6 +91,13 @@ export function verticalFilled (Component) {
       }
       this.setState({ height: height })
     },
+    scrollTo(top) {
+      const el = this.refs && this.refs.el
+      if (!el) return
+      if (el.scrollTo)
+        return el.scrollTo(top) // use the child's impl
+      ReactDOM.findDOMNode(this.refs.el).scrollTop = top
+    },
     render() {
       return <Component ref="el" {...this.props} {...this.state} />
     }

--- a/ui/com/modals.jsx
+++ b/ui/com/modals.jsx
@@ -73,7 +73,7 @@ export class SetupModal extends React.Component {
     const done = () => {
       if (++n >= m) {
         if (app.user.needsSetup)
-          window.location.hash = '#/help/welcome'
+          app.history.pushState(null, '/help/welcome')
         else
           app.fetchLatestState()
         this.onClose()

--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -18,6 +18,10 @@ import u from '../lib/util'
 // how many messages to fetch in a batch?
 const DEFAULT_BATCH_LOAD_AMT = 30
 
+// what's the avg height a message will be?
+// (used in loading calculations, when trying to scroll to a specific spot. doesnt need to be exact)
+const AVG_RENDERED_MSG_HEIGHT = 200
+
 // used when live msgs come in, how many msgs, from the top, should we check for deduplication?
 const DEDUPLICATE_LIMIT = 100
 
@@ -232,6 +236,16 @@ export default class MsgList extends React.Component {
     this.setState({ containerHeight: height })
   }
 
+  // infinite load call
+  onInfiniteLoad(scrollingTo) {
+    var amt = DEFAULT_BATCH_LOAD_AMT
+    if (scrollingTo) {
+      // trying to reach a dest, increase amount to load with a rough guess of how many are needed
+      amt = Math.max((scrollingTo / AVG_RENDERED_MSG_HEIGHT)|0, DEFAULT_BATCH_LOAD_AMT)
+    }
+    this.loadMore({ amt })
+  }
+
   processMsg(msg, cb) {
     // fetch thread data if not already present (using `related` as an indicator of that)
     if (this.props.threads && !('related' in msg)) {
@@ -345,7 +359,7 @@ export default class MsgList extends React.Component {
           elementHeight={this.props.listItemHeight||60}
           containerHeight={this.state.containerHeight}
           infiniteLoadBeginBottomOffset={this.state.isAtEnd ? undefined : 1200}
-          onInfiniteLoad={this.loadMore.bind(this, { amt: 30 })}
+          onInfiniteLoad={this.onInfiniteLoad.bind(this)}
           loadingSpinnerDelegate={this.loadingElement()}
           isInfiniteLoading={this.state.isLoading} >
           { this.props.hero ? this.props.hero() : '' }

--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -45,7 +45,7 @@ export default class MsgList extends React.Component {
     // handlers
     this.handlers = {
       onSelect: msg => {
-        window.location.hash = '#/msg/' + encodeURIComponent(msg.key)
+        app.history.pushState(null, '/msg/' + encodeURIComponent(msg.key))
       },
       onToggleBookmark: (msg) => {
         // toggle in the DB
@@ -355,6 +355,7 @@ export default class MsgList extends React.Component {
     return <div className={'msg-list'+(this.state.selected?' msg-is-selected':'')}>
       <div className="msg-list-items">
         <Infinite
+          id="msg-list-infinite"
           ref="container"
           elementHeight={this.props.listItemHeight||60}
           containerHeight={this.state.containerHeight}

--- a/ui/com/msg-thread.jsx
+++ b/ui/com/msg-thread.jsx
@@ -235,7 +235,7 @@ export default class Thread extends React.Component {
   }
 
   openMsg(id) {
-    window.location.hash = '#/msg/'+encodeURIComponent(id)
+    app.history.pushState(null, '/msg/'+encodeURIComponent(id))
   }
   onSelectRoot() {
     let thread = this.state.thread
@@ -261,7 +261,7 @@ export default class Thread extends React.Component {
             : '' }
         </div>
       </div>
-      <VerticalFilledContainer>
+      <VerticalFilledContainer id="msg-thread-vertical">
         <div className="items">
           { this.state.msgs.map((msg, i) => {
             const isFirst = (i === 0)

--- a/ui/com/simple-infinite.jsx
+++ b/ui/com/simple-infinite.jsx
@@ -47,7 +47,7 @@ class SimpleInfinite extends React.Component {
   }
 
   render() {
-    return <div ref="container" onScroll={this.onScroll} style={{height: this.props.height, overflow: 'auto'}}>{this.props.children}</div>
+    return <div id={this.props.id} className="vertical-filled" ref="container" onScroll={this.onScroll} style={{height: this.props.height, overflow: 'auto'}}>{this.props.children}</div>
   }
 }
 export default verticalFilled(SimpleInfinite)

--- a/ui/com/simple-infinite.jsx
+++ b/ui/com/simple-infinite.jsx
@@ -9,18 +9,43 @@ import { verticalFilled } from './index'
 class SimpleInfinite extends React.Component {
   constructor(props) {
     super(props)
+    this.scrollingTo = false
+
     this.onScroll = () => {
-      // stop checking if bottom offset isnt defined
-      if (!this.props.infiniteLoadBeginBottomOffset)
+      // stop checking if out of more content
+      if (!this.hasLoadableContent())
         return
 
       let el = this.refs.container
       if (el.offsetHeight + el.scrollTop + this.props.infiniteLoadBeginBottomOffset >= el.scrollHeight) {
         // hit bottom
-        this.props.onInfiniteLoad()
+        this.props.onInfiniteLoad(this.scrollingTo)
       }
     }
   }
+  
+  hasLoadableContent() {
+    // this is how react-infinite signals there's no more content -- when this var is falsey
+    return !!this.props.infiniteLoadBeginBottomOffset
+  }
+
+  // helper to scroll & load until a destination is reached
+  scrollTo(top) {
+    const el = this.refs && this.refs.container
+    if (!el) return
+    if (el.scrollTop == top || !this.hasLoadableContent()) {
+      this.scrollingTo = false
+      return // we're done
+    }
+
+    el.scrollTop = top
+    if (el.scrollTop !== top) { // didnt get all the way there?
+      this.scrollingTo = top
+      setTimeout(() => this.scrollTo(top), 1) // try again in 1ms, after more loading has had a chance to occur
+    } else
+      this.scrollingTo = false // done
+  }
+
   render() {
     return <div ref="container" onScroll={this.onScroll} style={{height: this.props.height, overflow: 'auto'}}>{this.props.children}</div>
   }

--- a/ui/com/user-list.jsx
+++ b/ui/com/user-list.jsx
@@ -73,7 +73,7 @@ export default class UserList extends React.Component {
     // handlers
     this.handlers = {
       onSelect: (user) => {
-        window.location = '#/profile/'+encodeURIComponent(user.id)
+        app.history.pushState(null, '/profile/'+encodeURIComponent(user.id))
       }
     }
   }

--- a/ui/lib/app.js
+++ b/ui/lib/app.js
@@ -16,6 +16,7 @@ var SSBClient = require('./muxrpc-ipc')
 var emojis    = require('emoji-named-characters')
 var Emitter   = require('events')
 var extend    = require('xtend/mutable')
+var createHashHistory = require('history').createHashHistory
 
 // event streams and listeners
 var patchworkEventStream = null
@@ -31,6 +32,7 @@ module.exports = extend(new Emitter(), {
   fetchLatestState: fetchLatestState,
 
   // ui data
+  history: createHashHistory(),
   isComposerOpen: false,
   suggestOptions: { 
     ':': Object.keys(emojis).map(function (emoji) {

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -1,6 +1,7 @@
 'use babel'
 import React from 'react'
 import { Router, Route, IndexRoute } from 'react-router'
+import app from './lib/app'
 import Layout from './layout'
 import NewsFeed from './views/newsfeed'
 import Notifications from './views/notifications'
@@ -13,8 +14,22 @@ import WebView from './views/webview'
 import Sync from './views/sync'
 import Help from './views/help'
 
+function beforeNavigation (nextState) {
+  if (nextState.action === 'PUSH') { // only on new navs, not on back-btn-driven navs
+    // capture scroll position of all vertical-filled components
+    var vfScrollTops = {}
+    var vfEls = Array.from(document.querySelectorAll('.vertical-filled'))
+    vfEls.forEach(el => {
+      if (el.id)
+        vfScrollTops[el.id] = el.scrollTop
+    })
+    window.history.replaceState({ vfScrollTops: vfScrollTops }, '')
+  }
+}
+
+app.history.listenBefore(beforeNavigation)
 export default (
-  <Router>
+  <Router history={app.history}>
     <Route path="/" component={Layout}>
       <IndexRoute component={NewsFeed} />
       <Route path="msg/:id" component={Msg} />


### PR DESCRIPTION
Very happy to submit this PR. Fixes https://github.com/ssbc/patchwork/issues/123

Scroll position of scrollable regions in the app are now stored inside the history state. On back-navigations, the scroll positions are restored.

Doesn't work perfectly. I notice, sometimes when transitioning from threads to other threads, the scroll position gets lost. Also, sometimes, the restored scroll position on lists is *close* but just a little different. But the basic algorithm seems to be fine, so we can fix those as we go, and enjoy the benefits of what works now.

One other note: the performance of restoring the scroll position, in msg-lists, is bad if loading needs to occur. This is something that will have to be made more efficient, most likely by caching messages. Again, because the basic algorithm wont be affected by fixing the load-speed, I decided to go ahead and land this.