### PR TITLE
Fix module load error in case-sensitive file system

### DIFF
--- a/ui/com/msg-list/bookmarks.jsx
+++ b/ui/com/msg-list/bookmarks.jsx
@@ -1,7 +1,7 @@
 'use babel'
 import React from 'react'
 import MsgList from '../msg-list'
-import Oneline from '../msg-view/Oneline'
+import Oneline from '../msg-view/oneline'
 import Tabs from '../tabs'
 import app from '../../lib/app'
 


### PR DESCRIPTION
Fixes this error
```
Error: Cannot find module '../msg-view/Oneline'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:286:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/usr/local/src/patchwork/ui/com/msg-list/bookmarks.jsx:3:34)
    at Module._compile (module.js:434:26)
    at normalLoader (/usr/local/src/patchwork/node_modules/babel/node_modules/babel-core/lib/api/register/node.js:199:5)
    at Object.require.extensions.(anonymous function) [as .jsx] (/usr/local/src/patchwork/node_modules/babel/node_modules/babel-core/lib/api/register/node.js:216:7)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
```