### PR TITLE
Tracking PR, newsfeed update proposal: discussions and live-stream modes 

### DIFF
--- a/api/processor.js
+++ b/api/processor.js
@@ -14,19 +14,10 @@ module.exports = function (sbot, db, state, emit) {
       var mentions = mlib.links(c.mentions)
 
       // newsfeed index: add public posts
-      if (!root && recps.length === 0) {
-        state.newsfeed.sortedUpsert(msg.value.timestamp, msg.key)
+      if (recps.length === 0) {
+        var newsfeedRow = state.newsfeed.sortedUpsert(msg.value.timestamp, msg.key)
+        newsfeedRow.root = root
         emit('index-change', { index: 'newsfeed' })
-      }
-
-      // newsfeed index: update for replies
-      var newsfeedRow
-      if (root) {
-        newsfeedRow = state.newsfeed.find(root.link)
-        if (newsfeedRow) {
-          state.newsfeed.sortedUpsert(msg.value.timestamp, root.link)
-          emit('index-change', { index: 'newsfeed' })
-        }
       }
 
       // bookmarks index: update for replies

--- a/api/test/indexes.js
+++ b/api/test/indexes.js
@@ -25,7 +25,7 @@ tape('newsfeed index includes all public posts', function (t) {
 
         pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
           if (err) throw err
-          t.equal(msgs.length, 2)
+          t.equal(msgs.length, 3)
           t.end()
           sbot.close()
         }))
@@ -55,14 +55,15 @@ tape('newsfeed index does not update the root message for replies', function (t)
           t.equal(msgs[0].key, msg2.key)
           t.equal(msgs[1].key, msg1.key)
 
-          users.charlie.add({ type: 'post', text: 'reply from charlie', root: msg1.key, branch: msg1.key }, function (err) {
+          users.charlie.add({ type: 'post', text: 'reply from charlie', root: msg1.key, branch: msg1.key }, function (err, msg3) {
             if (err) throw err
 
             pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
               if (err) throw err
-              t.equal(msgs.length, 2)
-              t.equal(msgs[0].key, msg2.key) // order of msgs was retained
-              t.equal(msgs[1].key, msg1.key)
+              t.equal(msgs.length, 3)
+              t.equal(msgs[0].key, msg3.key)
+              t.equal(msgs[1].key, msg2.key)
+              t.equal(msgs[2].key, msg1.key)
               t.end()
               sbot.close()
             }))

--- a/api/test/indexes.js
+++ b/api/test/indexes.js
@@ -34,7 +34,7 @@ tape('newsfeed index includes all public posts', function (t) {
   })
 })
 
-tape('newsfeed index updates the root message for replies', function (t) {
+tape('newsfeed index does not update the root message for replies', function (t) {
   var sbot = u.newserver()
   u.makeusers(sbot, {
     alice: {},
@@ -61,8 +61,8 @@ tape('newsfeed index updates the root message for replies', function (t) {
             pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
               if (err) throw err
               t.equal(msgs.length, 2)
-              t.equal(msgs[0].key, msg1.key) // order of msgs was reversed
-              t.equal(msgs[1].key, msg2.key)
+              t.equal(msgs[0].key, msg2.key) // order of msgs was retained
+              t.equal(msgs[1].key, msg1.key)
               t.end()
               sbot.close()
             }))

--- a/api/test/indexes.js
+++ b/api/test/indexes.js
@@ -4,7 +4,7 @@ var ssbkeys = require('ssb-keys')
 var pull    = require('pull-stream')
 var u       = require('./util')
 
-tape('newsfeed index includes all public posts', function (t) {
+tape('newsfeed index includes all public root posts but no replies, by default', function (t) {
   var sbot = u.newserver()
   u.makeusers(sbot, {
     alice: {},
@@ -24,6 +24,37 @@ tape('newsfeed index includes all public posts', function (t) {
         if (err) throw err
 
         pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
+          if (err) throw err
+          t.equal(msgs.length, 2)
+          t.end()
+          sbot.close()
+        }))
+      })
+    })
+  })
+})
+
+
+tape('newsfeed index includes all public posts and replies with includeReplies: true', function (t) {
+  var sbot = u.newserver()
+  u.makeusers(sbot, {
+    alice: {},
+    bob: {},
+    charlie: {}
+  }, function (err, users) {
+    if (err) throw err
+
+    users.alice.add({ type: 'post', text: 'hello from alice' }, function (err, msg) { // included
+      if (err) throw err
+
+      var done = multicb()
+      users.bob.add({ type: 'post', text: 'hello from bob' }, done()) // included
+      users.bob.add(ssbkeys.box({ type: 'post', text: 'secret hello from bob', recps: [users.alice.id, users.bob.id] }, [users.alice.keys, users.bob.keys]), done()) // not included
+      users.charlie.add({ type: 'post', text: 'reply from charlie', root: msg.key, branch: msg.key }, done()) // not included
+      done(function (err) {
+        if (err) throw err
+
+        pull(sbot.patchwork.createNewsfeedStream({ includeReplies: true }), pull.collect(function (err, msgs) {
           if (err) throw err
           t.equal(msgs.length, 3)
           t.end()
@@ -49,7 +80,7 @@ tape('newsfeed index does not update the root message for replies', function (t)
       users.bob.add({ type: 'post', text: 'hello from bob' }, function (err, msg2) {
         if (err) throw err
 
-        pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
+        pull(sbot.patchwork.createNewsfeedStream({includeReplies: true}), pull.collect(function (err, msgs) {
           if (err) throw err
           t.equal(msgs.length, 2)
           t.equal(msgs[0].key, msg2.key)
@@ -58,7 +89,7 @@ tape('newsfeed index does not update the root message for replies', function (t)
           users.charlie.add({ type: 'post', text: 'reply from charlie', root: msg1.key, branch: msg1.key }, function (err, msg3) {
             if (err) throw err
 
-            pull(sbot.patchwork.createNewsfeedStream(), pull.collect(function (err, msgs) {
+            pull(sbot.patchwork.createNewsfeedStream({includeReplies: true}), pull.collect(function (err, msgs) {
               if (err) throw err
               t.equal(msgs.length, 3)
               t.equal(msgs[0].key, msg3.key)


### PR DESCRIPTION
(Related: %oHSmA9ZDlrRN4ULK40eQ9syEDVItoVnx1GrrQ/BKEDs=.sha256)

Proposed update: would give the newsfeed two modes: Discussions and Live Stream. Discussions shows root posts only, in inbox-style rendering. Live Stream shows all posts (including replies) in feed-style rendering.

Motivation: splitting the feed into view-modes will let us read at a rate that fits the current interest. The discussions mode focuses on following discussions, while the live-stream mode is for browsing all activity.

Still todo: 
 - Discussions mode should expand threads inline
 - Discussions mode needs controls on the posts
 - Live-stream mode needs reply information on the message uis
 - Inbox hasnt been updated yet

Counter-proposals are welcome. Something to consider:
 - A third mode, live stream without replies