### PR TITLE
Thread view panel

### DIFF
--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -45,8 +45,10 @@ export default class MsgList extends React.Component {
     // handlers
     this.handlers = {
       onSelect: msg => {
-        app.emit('open:msg', msg.key)
-        // app.history.pushState(null, '/msg/' + encodeURIComponent(msg.key))
+        if (this.props.openMsgEvent)
+          app.emit('open:msg', msg.key)
+        else
+          app.history.pushState(null, '/msg/' + encodeURIComponent(msg.key))
       },
       onToggleBookmark: (msg) => {
         // toggle in the DB

--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -45,7 +45,8 @@ export default class MsgList extends React.Component {
     // handlers
     this.handlers = {
       onSelect: msg => {
-        app.history.pushState(null, '/msg/' + encodeURIComponent(msg.key))
+        app.emit('open:msg', msg.key)
+        // app.history.pushState(null, '/msg/' + encodeURIComponent(msg.key))
       },
       onToggleBookmark: (msg) => {
         // toggle in the DB

--- a/ui/com/msg-thread.jsx
+++ b/ui/com/msg-thread.jsx
@@ -196,10 +196,15 @@ export default class Thread extends React.Component {
   openMsg(id) {
     app.history.pushState(null, '/msg/'+encodeURIComponent(id))
   }
+
   onSelectRoot() {
     let thread = this.state.thread
     let threadRoot = mlib.link(thread.value.content.root, 'msg')
     this.openMsg(threadRoot.link)
+  }
+
+  onCloseMsg() {
+    app.emit('open:msg', null)
   }
 
   render() {
@@ -208,6 +213,9 @@ export default class Thread extends React.Component {
     const canMarkUnread = thread && (thread.isBookmarked || !thread.plaintext)
     return <div className="msg-thread">
       <div className="toolbar flex">
+        { this.props.closeBtn ?
+          <a className="btn" onClick={this.onCloseMsg.bind(this)}><i className="fa fa-times"/> Close</a>
+          : '' }
         { threadRoot ?
           <a className="btn" onClick={this.onSelectRoot.bind(this)}><i className="fa fa-angle-double-up" /> Parent Thread</a>
           : '' }

--- a/ui/com/msg-view/summary.jsx
+++ b/ui/com/msg-view/summary.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import mlib from 'ssb-msgs'
 import threadlib from 'patchwork-threads'
-import { UserLinks, NiceDate } from '../index'
+import { UserLink, NiceDate } from '../index'
 import { Inline as Content } from '../msg-content'
 import { countReplies } from '../../lib/msg-relation'
 import u from '../../lib/util'
@@ -14,9 +14,6 @@ export default class Summary extends React.Component {
 
   render() {
     let msg = this.props.msg
-    let recps = mlib.links(msg.value.content.recps, 'feed').map(link => link.link).filter(id => id !== app.user.id)
-    if (recps.length === 0)
-      recps = [msg.value.author]
     let lastMsg = !this.props.forceRaw ? threadlib.getLastThreadPost(msg) : false
     var replies = countReplies(msg)
     replies = (replies === 0) ? '' : '('+replies+')'
@@ -32,7 +29,7 @@ export default class Summary extends React.Component {
       <div className="content">
         <div className="header">
           <div className="header-left">
-            { msg.plaintext ? '' : <i className="fa fa-lock"/> } <UserLinks ids={recps} />{' '}
+            { msg.plaintext ? '' : <i className="fa fa-lock"/> } <UserLink id={msg.value.author} />{' '}
             {replies} {msg.mentionsUser ? <i className="fa fa-at"/> : ''}
           </div>
           <div className="header-right"><NiceDate ts={(lastMsg||msg).value.timestamp} /></div>

--- a/ui/com/msg-view/summary.jsx
+++ b/ui/com/msg-view/summary.jsx
@@ -16,7 +16,7 @@ export default class Summary extends React.Component {
     let msg = this.props.msg
     let lastMsg = !this.props.forceRaw ? threadlib.getLastThreadPost(msg) : false
     var replies = countReplies(msg)
-    replies = (replies === 0) ? '' : '('+replies+')'
+    replies = (replies === 0) ? '' : '('+(replies+1)+')'
     return <div className={'msg-view summary'+(this.props.selected ? ' selected' : '')+(msg.hasUnread ? ' unread' : '')} onClick={this.onClick.bind(this)}>
       { this.props.ctrls ?
         <div className="ctrls">

--- a/ui/layout.jsx
+++ b/ui/layout.jsx
@@ -126,12 +126,13 @@ export default class Layout extends React.Component {
             <NavLink to="/sync" icon={isWifiMode?'wifi':'globe'} label='Network' />
             <Issues />
           </div>
+          <div className="divider" />
+          <NavToggle to="msg" icon="envelope" count={this.state.indexCounts.bookmarksUnread} />
+          <NavToggle to="bookmarks" icon="bookmark" count={this.state.indexCounts.bookmarksUnread} />
+          <NavToggle to="notifications" icon="bell" count={this.state.indexCounts.notificationsUnread} />
         </div>
         <div>
           <div className="search"><i className="fa fa-search" /><input onKeyDown={this.onSearchKeyDown.bind(this)} /></div>
-          <NavToggle to="msg" icon="envelope-o" count={this.state.indexCounts.bookmarksUnread} />
-          <NavToggle to="bookmarks" icon="bookmark-o" count={this.state.indexCounts.bookmarksUnread} />
-          <NavToggle to="notifications" icon="bell-o" count={this.state.indexCounts.notificationsUnread} />
         </div>
       </div>
       <div className="layout-columns">

--- a/ui/layout.jsx
+++ b/ui/layout.jsx
@@ -5,7 +5,6 @@ import ssbref from 'ssb-ref'
 import app from './lib/app'
 import Notifications from './com/msg-list/notifications'
 import Bookmarks from './com/msg-list/bookmarks'
-import Msg from './views/msg'
 import ModalFlow from './com/modals/flow'
 import ProfileSetup from './com/forms/profile-setup'
 import FollowNearby from './com/forms/follow-nearby'
@@ -16,8 +15,7 @@ const SETUP_LABELS = [<i className="fa fa-user"/>, <i className="fa fa-wifi"/>, 
 const SETUP_FORMS = [ProfileSetup, FollowNearby, PubInvite]
 const RIGHT_NAVS = {
   notifications: Notifications,
-  bookmarks: Bookmarks,
-  msg: Msg
+  bookmarks: Bookmarks
 }
 
 export default class Layout extends React.Component {
@@ -31,7 +29,6 @@ export default class Layout extends React.Component {
     app.on('update:indexCounts', refresh)
     app.on('update:isWifiMode', refresh)
     app.on('modal:setup', (isOpen) => this.setState({ setupIsOpen: isOpen }))
-    app.on('open:msg', this.onOpenMsg.bind(this))
   }
   componentWillReceiveProps() {
     // update state on view changes
@@ -57,16 +54,6 @@ export default class Layout extends React.Component {
       this.setState({ rightNav: false, rightNavProps: {} })
     else
       this.setState({ rightNav: id })
-  }
-
-  onOpenMsg(key) {
-    if (this.state.rightNav == 'msg') {
-      // if the message rightnav is open, update to that
-      this.setState({ rightNavProps: { params: { id: key } } })
-    } else {
-      // otherwise, navigate
-      app.history.pushState(null, '/msg/' + encodeURIComponent(key))
-    }
   }
 
   onClickBack() {
@@ -127,7 +114,6 @@ export default class Layout extends React.Component {
             <Issues />
           </div>
           <div className="divider" />
-          <NavToggle to="msg" icon="envelope" count={this.state.indexCounts.bookmarksUnread} />
           <NavToggle to="bookmarks" icon="bookmark" count={this.state.indexCounts.bookmarksUnread} />
           <NavToggle to="notifications" icon="bell" count={this.state.indexCounts.notificationsUnread} />
         </div>

--- a/ui/less/com/composer.less
+++ b/ui/less/com/composer.less
@@ -69,9 +69,7 @@
     }
   }
   .composer-ctrls {
-    background: #f5f5f5;
     font-weight: 300;
-    border-top: 1px solid #ddd;
     
     .btn {
       padding: 10px 20px;

--- a/ui/less/com/markdown.less
+++ b/ui/less/com/markdown.less
@@ -4,6 +4,11 @@
 .markdown-block > :last-child {
   margin-bottom: 0 !important;
 }
-.markdown img {
-  max-width: 100%;
+.markdown {
+  h1, h2, h3, h4, h5 {
+    font-weight: 300;
+  }
+  img {
+    max-width: 100%;
+  }
 }

--- a/ui/less/com/msg-list.less
+++ b/ui/less/com/msg-list.less
@@ -49,6 +49,6 @@
     padding: 5px;
   }
   .msg-view.card-post {
-    margin: 20px auto;
+    margin: 10px auto;
   }
 }

--- a/ui/less/com/msg-thread.less
+++ b/ui/less/com/msg-thread.less
@@ -3,21 +3,6 @@
   .items {
     position: relative;
     padding: 0 0 100px;
-
-    .msg-view {
-      position: relative;
-      &:before {
-        content: '';
-        display: block;
-        position: absolute;
-        left: 91px;
-        width: 2px;
-        background: #d5d5d5;
-        z-index: 0;
-        bottom: -21px;
-        height: 20px;
-      }
-    }
   }
   .container {
     max-width: 660px;
@@ -27,7 +12,6 @@
     max-width: 583px;
     margin: 0 0 0 77px;
     padding-top: 1px; // make background take full space
-    box-shadow: none;
     .toolbar {
       display: none;
     }

--- a/ui/less/com/msg-view/card.less
+++ b/ui/less/com/msg-view/card.less
@@ -1,7 +1,7 @@
 .msg-view.card-post {
   display: flex;
   max-width: 660px;
-  margin: 20px auto;
+  margin: 10px auto;
 
   .left-meta {
     flex: 0 0 74px;
@@ -34,6 +34,8 @@
     color: @gray1;
     .header-left {
       flex: 1;
+      font-size: 21px;
+      font-weight: 300;
     }
     .header-right {
       white-space: pre;
@@ -59,12 +61,10 @@
   }
   .ctrls {
     display: flex;
-    background-color: #fafafa;
     padding: 5px 0;
     color: #808080;
     font-weight: 300;
     font-size: 15px;
-    border-top: 1px solid #eee;
     white-space: pre;
     & > div {
       padding: 0 10px;

--- a/ui/less/com/msg-view/notification.less
+++ b/ui/less/com/msg-view/notification.less
@@ -3,10 +3,7 @@
   overflow: hidden;
   border-bottom: 1px solid #ddd;
   transition: background 0.2s;
-
-  &.new {
-    background: #FFF;
-  }
+  background: #FFF;
 
   .ctrls {
     flex: 0 0 40px;
@@ -24,7 +21,8 @@
       color: #000;
     }
     .subject {
-      overflow : hidden;
+      color: #555;
+      overflow: hidden;
       text-overflow: ellipsis;
       display: -webkit-box;
       -webkit-line-clamp: 2;
@@ -35,6 +33,13 @@
     div:last-child {
       font-weight: 300;
       font-size: 12px;    
+    }
+  }
+
+  &.new {
+    border-left: 4px solid #006EFF;
+    .content .subject {
+      color: #006EFF;
     }
   }
 }

--- a/ui/less/com/msg-view/summary.less
+++ b/ui/less/com/msg-view/summary.less
@@ -3,8 +3,9 @@
   display: flex;
   padding: 10px;
   overflow: hidden;
-  border-bottom: 1px solid #ddd;
   background: #fff;
+  border-bottom: 1px solid #ddd;
+  border-left: 4px solid #ccc;
 
   .ctrls {
     flex: 0 0 24px;

--- a/ui/less/com/msg-view/summary.less
+++ b/ui/less/com/msg-view/summary.less
@@ -1,15 +1,10 @@
 .msg-view.summary {
+  .elevation-card;
   display: flex;
   padding: 10px;
   overflow: hidden;
-  max-width: 680px;
-  margin: 0 auto;
   border-bottom: 1px solid #ddd;
-
-  &:hover {
-    background: #fefefe;
-    cursor: pointer;
-  }
+  background: #fff;
 
   .ctrls {
     flex: 0 0 24px;
@@ -32,9 +27,14 @@
     color: @gray1;
     .header-left {
       flex: 1;
+      font-size: 21px;
+      font-weight: 300;
     }
     .header-right {
       font-weight: 300;
+    }
+    i {
+      color: @dark-gray3;
     }
     a {
       color: @dark-gray2;
@@ -45,13 +45,13 @@
     color: @dark-gray3;
     font-weight: 300;
     font-family: Helvetica;
-    line-height: 1.2;
+    line-height: 1.4;
 
     .body-line {
       overflow: hidden;
       text-overflow: ellipsis;
       display: -webkit-box;
-      -webkit-line-clamp: 3;
+      -webkit-line-clamp: 1;
       -webkit-box-orient: vertical;
       &:nth-child(2) {
         color: gray;
@@ -61,16 +61,17 @@
   }
 
   &.unread {
-    background: @white3;
+    background: #fff;
+    border-left: 4px solid #006EFF;
     .header-left, .header-right {
-      font-weight: bold;
       color: @dark-gray2;
-    }
-    i {
-      color: @dark-gray3;
     }
     .body {
       font-weight: 500;
+      .body-line:first-child {
+        color: #006EFF;
+        font-weight: bold;
+      }
     }
   }
 
@@ -92,5 +93,9 @@
       color: @white2;
       background: rgba(255,255,255,0.25);
     }
+  }
+  &:hover {
+    background: #fafafa;
+    cursor: pointer;
   }
 }

--- a/ui/less/com/toolbar.less
+++ b/ui/less/com/toolbar.less
@@ -23,6 +23,7 @@
   }
 
   .divider {
+    display: inline;
     width: 1px;
     border-left: 1px solid #ccc;
     margin: 0 12px;

--- a/ui/less/com/toolbar.less
+++ b/ui/less/com/toolbar.less
@@ -1,9 +1,9 @@
 .toolbar {
-  background: #fafafa;
+  background: #fff;
   border-bottom: 1px solid #ccc;
   font-weight: 300;
   height: 28px;
-  padding: 5px 0;
+  padding: 5px;
 
   .centered {
     width: 645px;

--- a/ui/less/common.less
+++ b/ui/less/common.less
@@ -78,8 +78,3 @@ blockquote {
   padding-bottom: 0.25em;
   color: @dark-gray2;
 }
-
-// Bookmark icon colors
-.fa-bookmark {
-  color: #EFBD32 !important;
-}

--- a/ui/less/views/inbox.less
+++ b/ui/less/views/inbox.less
@@ -1,0 +1,6 @@
+#inbox {
+  .msg-view {
+    margin: 10px auto;
+    max-width: 640px;
+  }
+}

--- a/ui/less/views/inbox.less
+++ b/ui/less/views/inbox.less
@@ -1,6 +1,6 @@
 #inbox {
   .msg-view.summary {
-    margin: 10px auto;
+    margin: 5px auto;
     max-width: 640px;
   }
 }

--- a/ui/less/views/inbox.less
+++ b/ui/less/views/inbox.less
@@ -1,5 +1,5 @@
 #inbox {
-  .msg-view {
+  .msg-view.summary {
     margin: 10px auto;
     max-width: 640px;
   }

--- a/ui/less/views/newsfeed.less
+++ b/ui/less/views/newsfeed.less
@@ -1,10 +1,17 @@
-#newsfeed .msg-list-items .toolbar {
-  padding: 5px;
-  background: none;
-  border: 0;
-  &.floating {
-    position: static;
-    width: 0; height: 0;
-    float: left;
+#newsfeed {
+  .msg-list-items .toolbar {
+    padding: 5px;
+    background: none;
+    border: 0;
+    &.floating {
+      position: static;
+      width: 0; height: 0;
+      float: left;
+    }
+  }
+
+  .msg-view.summary {
+    margin: 10px auto;
+    max-width: 640px;
   }
 }

--- a/ui/less/views/newsfeed.less
+++ b/ui/less/views/newsfeed.less
@@ -1,8 +1,14 @@
 #newsfeed {
+  display: flex;
+
+  .msg-list {
+    flex: 1;
+  }
+  .msg-thread {
+    flex: 0 0 680px;
+  }
+
   .msg-list-items .toolbar {
-    padding: 5px;
-    background: none;
-    border: 0;
     &.floating {
       position: static;
       width: 0; height: 0;

--- a/ui/less/views/newsfeed.less
+++ b/ui/less/views/newsfeed.less
@@ -5,6 +5,7 @@
     flex: 1;
   }
   .msg-thread {
+    border-left: 1px solid #ccc;
     flex: 0 0 680px;
   }
 
@@ -17,7 +18,7 @@
   }
 
   .msg-view.summary {
-    margin: 10px auto;
+    margin: 5px auto;
     max-width: 640px;
   }
 }

--- a/ui/less/views/rightnav.less
+++ b/ui/less/views/rightnav.less
@@ -1,6 +1,10 @@
 #rightnav {
-  background: #fafafa;
-  width: 350px;
+  .bookmarks, .notifications {
+    width: 350px;
+  }
+  #msg {
+    width: 680px;
+  }
   border-left: 1px solid #ccc;
   .toolbar .tabs {
     display: flex;

--- a/ui/less/views/rightnav.less
+++ b/ui/less/views/rightnav.less
@@ -1,16 +1,18 @@
 #rightnav {
+    border-left: 1px solid #ccc;
   .bookmarks, .notifications {
     width: 350px;
   }
   #msg {
     width: 680px;
   }
-  border-left: 1px solid #ccc;
-  .toolbar .tabs {
-    display: flex;
-    a {
-      flex: 1;
-      text-align: center;
+  .toolbar {
+    .tabs {
+      display: flex;
+      a {
+        flex: 1;
+        text-align: center;
+      }
     }
   }
   .msg-view.summary .body .body-line {

--- a/ui/less/views/rightnav.less
+++ b/ui/less/views/rightnav.less
@@ -9,4 +9,7 @@
       text-align: center;
     }
   }
+  .msg-view.summary .body .body-line {
+    -webkit-line-clamp: 3;
+  }
 }

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -3,7 +3,7 @@ import React from 'react'
 import pull from 'pull-stream'
 import mlib from 'ssb-msgs'
 import MsgList from '../com/msg-list'
-import Oneline from '../com/msg-view/oneline'
+import Summary from '../com/msg-view/summary'
 import * as HelpCards from '../com/help/cards'
 import app from '../lib/app'
 
@@ -35,7 +35,7 @@ export default class Inbox extends React.Component {
         threads
         dateDividers
         composer composerProps={{placeholder: 'Write a new private message'}}
-        ListItem={Oneline}
+        ListItem={Summary}
         live={{ gt: [Date.now(), null] }}
         emptyMsg="Your inbox is empty."
         append={this.helpCards.bind(this)}

--- a/ui/views/msg.jsx
+++ b/ui/views/msg.jsx
@@ -7,8 +7,11 @@ import u from '../lib/util'
 
 export default class Msg extends React.Component {
   render() {
+    const id = this.props.params && this.props.params.id
     return <div id="msg">
-      <Thread id={this.props.params.id} live />
+      { id
+        ? <Thread id={id} live />
+        : <div style={{padding: 20, fontWeight: 300, textAlign:'center'}}>No thread selected.</div> }
     </div>
   }
 }

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -7,10 +7,17 @@ import Dipswitch from '../com/form-elements/dipswitch'
 import Tabs from '../com/tabs'
 import MsgList from '../com/msg-list'
 import Card from '../com/msg-view/card'
+import Summary from '../com/msg-view/summary'
 import * as HelpCards from '../com/help/cards'
 import app from '../lib/app'
 import social from '../lib/social-graph'
 
+const LISTITEMS = [
+  { label: <i className="fa fa-picture-o" />, Component: Card },
+  { label: <i className="fa fa-th-list" />, Component: Summary }
+]
+const LISTITEM_CARD = LISTITEMS[0]
+const LISTITEM_ONELINE = LISTITEMS[1]
 
 function followedOnlyFilter (msg) {
   return msg.value.author === app.user.id || social.follows(app.user.id, msg.value.author)
@@ -20,6 +27,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
   constructor(props) {
     super(props, 'newsfeedState', {
       isToolbarOpen: true,
+      listItemIndex: 0,
       isFollowedOnly: false
     })
   }
@@ -43,6 +51,10 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
     })
   }
 
+  onSelectListItem(listItem) {
+    this.setState({ listItemIndex: LISTITEMS.indexOf(listItem) })
+  }
+
   onToggleFollowedOnly(b) {
     this.setState({ isFollowedOnly: b }, () => {
       this.refs.list.reload()
@@ -50,6 +62,8 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
   }
 
   render() {
+    const listItem = LISTITEMS[this.state.listItemIndex]
+    const ListItem = listItem.Component
     const Hero = (props) => {
       if (!this.state.isToolbarOpen) {
         return <div className="toolbar floating">
@@ -60,6 +74,8 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
         <a className="btn" onClick={this.onToggleToolbar.bind(this)}><i className="fa fa-check" /> Done</a>
         <span className="divider" />
         <Dipswitch label={this.state.isFollowedOnly?"Followed Only":"All Users"} checked={this.state.isFollowedOnly} onToggle={this.onToggleFollowedOnly.bind(this)} />
+        <span className="divider" />
+        <Tabs options={LISTITEMS} selected={listItem} onSelect={this.onSelectListItem.bind(this)} />
       </div>
     }
     const filter = msg => {
@@ -77,7 +93,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
         dateDividers
         filter={filter}
         Hero={Hero}
-        ListItem={Card}
+        ListItem={ListItem}
         live={{ gt: [Date.now(), null] }}
         emptyMsg="Your newsfeed is empty."
         append={this.helpCards.bind(this)}

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -115,6 +115,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
         composer composerProps={{isPublic: true, placeholder: 'Write a new public post'}}
         queueNewMsgs
         dateDividers
+        openMsgEvent
         filter={filter}
         Hero={Hero}
         ListItem={ListItem}


### PR DESCRIPTION
This PR does some styling update to the messages, and adds a toggleable message-view on the right nav, which  shows threads you click. If you disable the thread-view panel, it'll do a normal page navigation.

**Updated feed styles**
![screen shot 2015-12-15 at 1 22 12 am](https://cloud.githubusercontent.com/assets/1270099/11804591/a7977eac-a2ca-11e5-981b-31c99f4de1dd.png)
**Updated inbox styles**
![screen shot 2015-12-15 at 1 22 51 am](https://cloud.githubusercontent.com/assets/1270099/11804590/a797486a-a2ca-11e5-81ce-128f53cb20f2.png)
**thread selected**
![screen shot 2015-12-15 at 1 23 12 am](https://cloud.githubusercontent.com/assets/1270099/11804588/a796d998-a2ca-11e5-8cc8-266ec941f5b6.png)
**in the feed view**
![screen shot 2015-12-15 at 1 23 19 am](https://cloud.githubusercontent.com/assets/1270099/11804589/a7976318-a2ca-11e5-8fca-902cfa2a13c7.png)
