### PR TITLE
Menu updates

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -220,15 +220,14 @@ module.exports = function (window) {
         }
       ]
     },
-    {
+    isMac ? {
       label: 'Window',
       submenu: [
         {
           label: 'Minimize',
           accelerator: 'CmdOrCtrl+M',
           role: 'minimize'
-        }
-      ].concat(isMac ? [
+        },
         {
           type: 'separator'
         },
@@ -236,8 +235,8 @@ module.exports = function (window) {
           label: 'Bring All to Front',
           selector: 'arrangeInFront:'
         }
-      ] : [])
-    }
+      ]
+    } : {}
   ]
 
   menu = Menu.buildFromTemplate(template)

--- a/app/menu.js
+++ b/app/menu.js
@@ -190,6 +190,16 @@ module.exports = function (window) {
           click: function () {
             window.rpc.navigate('/data')
           }
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Search',
+          accelerator: 'CmdOrCtrl+K',
+          click: function () {
+            window.rpc.focusSearch()
+          }
         }
       ]
     },

--- a/app/menu.js
+++ b/app/menu.js
@@ -119,6 +119,23 @@ module.exports = function (window) {
           type: 'separator'
         },
         {
+          label: 'Toggle Bookmarks',
+          accelerator: 'CmdOrCtrl+Shift+B',
+          click: function() {
+            window.rpc.navigateToggle('bookmarks')
+          }
+        },
+        {
+          label: 'Toggle Notifications',
+          accelerator: 'CmdOrCtrl+Shift+N',
+          click: function() {
+            window.rpc.navigateToggle('notifications')
+          }
+        },
+        {
+          type: 'separator'
+        },
+        {
           label: 'Toggle DevTools',
           accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
           click: function() { 

--- a/app/menu.js
+++ b/app/menu.js
@@ -8,11 +8,11 @@ module.exports = function (window) {
     {
       label: 'Patchwork',
       submenu: [
+      ].concat(isMac ? [
         {
           label: 'About Patchwork',
           selector: 'orderFrontStandardAboutPanel:'
-        }
-      ].concat(isMac ? [
+        },
         {
           type: 'separator'
         },
@@ -29,11 +29,11 @@ module.exports = function (window) {
         {
           label: 'Show All',
           selector: 'unhideAllApplications:'
-        }
-      ] : [], [
+        },
         {
           type: 'separator'
         },
+      ] : [], [
         {
           label: 'Quit',
           accelerator: 'CmdOrCtrl+Q',

--- a/app/menu.js
+++ b/app/menu.js
@@ -119,34 +119,76 @@ module.exports = function (window) {
           type: 'separator'
         },
         {
-          label: 'Reload',
-          accelerator: 'CmdOrCtrl+R',
-          click: function() { 
-            window.resetRpc()
-            window.reload()
-          }
-        },
-        {
           label: 'Toggle DevTools',
           accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
           click: function() { 
             window.toggleDevTools()
             // window.rpc.contextualToggleDevTools()
           }
+        }
+      ]
+    },
+    {
+      label: 'Go',
+      submenu: [
+        {
+          label: 'Back',
+          accelerator: 'Alt+Left',
+          click: function() {
+            window.rpc.navigateHistory(-1)
+          }
+        },
+        {
+          label: 'Forward',
+          accelerator: 'Alt+Right',
+          click: function() {
+            window.rpc.navigateHistory(1)
+          }
+        },
+        {
+          label: 'Reload',
+          accelerator: 'CmdOrCtrl+R',
+          click: function() {
+            window.resetRpc()
+            window.reload()
+          }
         },
         {
           type: 'separator'
         },
         {
-          label: 'Data Log',
+          label: 'Feed',
+          accelerator: 'CmdOrCtrl+1',
           click: function () {
-            window.rpc.navigate('/data')
+            window.rpc.navigate('/')
+          }
+        },
+        {
+          label: 'Inbox',
+          accelerator: 'CmdOrCtrl+2',
+          click: function () {
+            window.rpc.navigate('/inbox')
+          }
+        },
+        {
+          label: 'Contacts',
+          accelerator: 'CmdOrCtrl+3',
+          click: function () {
+            window.rpc.navigate('/profile')
           }
         },
         {
           label: 'Network Status',
+          accelerator: 'CmdOrCtrl+4',
           click: function () {
             window.rpc.navigate('/sync')
+          }
+        },
+        {
+          label: 'Data Log',
+          accelerator: 'CmdOrCtrl+5',
+          click: function () {
+            window.rpc.navigate('/data')
           }
         }
       ]

--- a/app/muxrpc-ipc.js
+++ b/app/muxrpc-ipc.js
@@ -6,6 +6,7 @@ var pullipc    = require('pull-ipc')
 var clientApi = {
   navigate: 'async',
   navigateHistory: 'async',
+  navigateToggle: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
   focusSearch: 'async',

--- a/app/muxrpc-ipc.js
+++ b/app/muxrpc-ipc.js
@@ -8,6 +8,7 @@ var clientApi = {
   navigateHistory: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
+  focusSearch: 'async',
   zoomIn: 'async',
   zoomOut: 'async',
   zoomReset: 'async'

--- a/app/muxrpc-ipc.js
+++ b/app/muxrpc-ipc.js
@@ -5,6 +5,7 @@ var pullipc    = require('pull-ipc')
 
 var clientApi = {
   navigate: 'async',
+  navigateHistory: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
   zoomIn: 'async',

--- a/ui/layout.jsx
+++ b/ui/layout.jsx
@@ -28,6 +28,7 @@ export default class Layout extends React.Component {
     app.on('update:all', refresh)
     app.on('update:indexCounts', refresh)
     app.on('update:isWifiMode', refresh)
+    app.on('focus:search', this.focusSearch.bind(this))
     app.on('modal:setup', isOpen => this.setState({ setupIsOpen: isOpen }))
   }
   componentWillReceiveProps() {
@@ -54,6 +55,10 @@ export default class Layout extends React.Component {
       this.setState({ rightNav: false, rightNavProps: {} })
     else
       this.setState({ rightNav: id })
+  }
+
+  focusSearch() {
+     this.refs.search.focus()
   }
 
   onClickBack() {
@@ -117,7 +122,7 @@ export default class Layout extends React.Component {
           <NavToggle to="notifications" icon="bell" count={this.state.indexCounts.notificationsUnread} />
         </div>
         <div>
-          <div className="search"><i className="fa fa-search" /><input onKeyDown={this.onSearchKeyDown.bind(this)} /></div>
+          <div className="search"><i className="fa fa-search" /><input ref="search" onKeyDown={this.onSearchKeyDown.bind(this)} /></div>
         </div>
       </div>
       <div className="layout-columns">

--- a/ui/layout.jsx
+++ b/ui/layout.jsx
@@ -29,6 +29,7 @@ export default class Layout extends React.Component {
     app.on('update:indexCounts', refresh)
     app.on('update:isWifiMode', refresh)
     app.on('focus:search', this.focusSearch.bind(this))
+    app.on('toggle:rightnav', this.toggleRightNav.bind(this))
     app.on('modal:setup', isOpen => this.setState({ setupIsOpen: isOpen }))
   }
   componentWillReceiveProps() {

--- a/ui/lib/muxrpc-ipc.js
+++ b/ui/lib/muxrpc-ipc.js
@@ -4,12 +4,20 @@ var pull       = require('pull-stream')
 var pullipc    = require('pull-ipc')
 var remote     = require('remote')
 var webFrame   = require('web-frame')
+var app
+
+function getApp() {
+  if (!app)
+    app = require('./app')
+  return app
+}
 
 var clientApiManifest = {
   navigate: 'async',
   navigateHistory: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
+  focusSearch: 'async',
   zoomIn: 'async',
   zoomOut: 'async',
   zoomReset: 'async'
@@ -32,6 +40,10 @@ var clientApi = {
   },
   triggerFind: function (cb) {
     // ui.triggerFind() :TODO:
+    cb()
+  },
+  focusSearch: function (cb) {
+    getApp().emit('focus:search')
     cb()
   },
   zoomIn: function (cb) {

--- a/ui/lib/muxrpc-ipc.js
+++ b/ui/lib/muxrpc-ipc.js
@@ -7,6 +7,7 @@ var webFrame   = require('web-frame')
 
 var clientApiManifest = {
   navigate: 'async',
+  navigateHistory: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
   zoomIn: 'async',
@@ -19,6 +20,10 @@ var zoomStep = 0.5;
 var clientApi = {
   navigate: function (path, cb) {
     window.location.hash = '#'+path
+    cb()
+  },
+  navigateHistory: function (direction, cb) {
+    window.history.go(direction)
     cb()
   },
   contextualToggleDevTools: function (cb) {

--- a/ui/lib/muxrpc-ipc.js
+++ b/ui/lib/muxrpc-ipc.js
@@ -15,6 +15,7 @@ function getApp() {
 var clientApiManifest = {
   navigate: 'async',
   navigateHistory: 'async',
+  navigateToggle: 'async',
   contextualToggleDevTools: 'async',
   triggerFind: 'async',
   focusSearch: 'async',
@@ -32,6 +33,10 @@ var clientApi = {
   },
   navigateHistory: function (direction, cb) {
     window.history.go(direction)
+    cb()
+  },
+  navigateToggle: function (id, cb) {
+    getApp().emit('toggle:rightnav', id)
     cb()
   },
   contextualToggleDevTools: function (cb) {


### PR DESCRIPTION
General changes
- Add a "Go" menu for navigation items. Move Reload into it.
  - Add back/forward
  - Add items for navigating to top-level UI (Feed, Inbox, etc)
  - Add item for jumping to the Search bar
- Add items for toggling the UI nav right sidebars

Non-OS X changes
- Remove About item which doesn't work. We can add it back after we make our own About window with useful info like the license, list of contributors, link to web site, etc
- Remove Minimize item. Generally window managers if they support Minimize provide their own key/interface for it. (Correct me if yours doesn't and you think this item should stay)