### PR TITLE
bump electron-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "electron-builder": "^2.0.0",
     "electron-packager": "^4.1.3",
-    "electron-prebuilt": "^0.36.1",
     "less": "~1.7.5",
     "osenv": "~0.1.0",
     "rimraf": "~2.2.8",
@@ -39,7 +38,7 @@
     "babel": "^5.8.23",
     "blob-to-buffer": "^1.2.3",
     "classnames": "^2.2.1",
-    "electron-prebuilt": "^0.33.7",
+    "electron-prebuilt": "^0.36.1",
     "emoji-named-characters": "^1.0.1",
     "history": "1.13.1",
     "hyperscript": "~1.4.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "electron-builder": "^2.0.0",
     "electron-packager": "^4.1.3",
-    "electron-prebuilt": "^0.33.7",
+    "electron-prebuilt": "^0.36.1",
     "less": "~1.7.5",
     "osenv": "~0.1.0",
     "rimraf": "~2.2.8",


### PR DESCRIPTION
This fixes an error on node v5. The newer versions electron-prebuilt have electron that is compiled against node v5. 