### PR TITLE
extract refs from http urls when found in markdown content

### DIFF
--- a/ui/lib/markdown.js
+++ b/ui/lib/markdown.js
@@ -19,7 +19,7 @@ blockRenderer.urltransform = function (url) {
     } catch (e) {
       return false;
     }
-    if (prot.indexOf('http:') !== 0 && prot.indexOf('https:') !== 0) {
+    if (prot.indexOf('http:') !== 0 && prot.indexOf('https:') !== 0 && prot.indexOf('data:') !== 0) {
       return false;
     }
   }


### PR DESCRIPTION
This is a PR to the `hosted` active PR. It depends on https://github.com/ssbc/ssb-ref/pull/7, so I put it in a separate branch.