### PR TITLE
Show recipient pics in PM threads

### DIFF
--- a/ui/com/hexagons.jsx
+++ b/ui/com/hexagons.jsx
@@ -38,7 +38,11 @@ export class UserHexagrid extends React.Component {
     })
     if (row.length)
       els.push(<div key={els.length}>{row}</div>)
-    return <div className={'user-hexagrid-'+size}>{els}</div>
+
+    var cls = 'user-hexagrid-'+size
+    if (this.props.horizontal)
+      cls += ' horizontal'
+    return <div className={cls}>{els}</div>
   }
 }
 

--- a/ui/com/msg-thread.jsx
+++ b/ui/com/msg-thread.jsx
@@ -4,7 +4,7 @@ import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import mlib from 'ssb-msgs'
 import schemas from 'ssb-msg-schemas'
 import threadlib from 'patchwork-threads'
-import { VerticalFilledContainer } from './index'
+import { VerticalFilledContainer, UserPics } from './index'
 import LeftNav from './leftnav'
 import ResponsiveElement from './responsive-element'
 import Card from './msg-view/card'
@@ -213,8 +213,9 @@ export default class Thread extends React.Component {
     const thread = this.state.thread
     const threadRoot = thread && mlib.link(thread.value.content.root, 'msg')
     const canMarkUnread = thread && (thread.isBookmarked || !thread.plaintext)
-    const publicOrPrivate = (thread && thread.plaintext) ? 'Public' : 'Private'
+    const isPublic = (thread && thread.plaintext)
     const authorName = thread && u.getName(thread.value.author)
+    const recps = thread && mlib.links(thread.value.content.recps, 'feed')
     return <div className="msg-thread">
       <VerticalFilledContainer id="msg-thread-vertical" className="flex">
         <LeftNav location={this.props.location} />
@@ -233,7 +234,10 @@ export default class Thread extends React.Component {
                     ? <UnreadBtn onClick={this.onToggleUnread.bind(this)} isUnread={thread.hasUnread} />
                     : '' }
                 </div>
-                <hr className="labeled" data-label={`${publicOrPrivate} post by ${authorName}`} />
+                <hr className="labeled" data-label={`${isPublic?'Public':'Private'} post by ${authorName}${isPublic?'':' to:'}`} />
+                { recps && recps.length
+                  ? <div className="recps-list flex"><div className="flex-fill"/><UserPics ids={recps.map(r => r.link)} /><div className="flex-fill"/></div>
+                  : '' }
                 <ReactCSSTransitionGroup component="div" className="items" transitionName="fade" transitionAppear={true} transitionAppearTimeout={500} transitionEnterTimeout={500} transitionLeaveTimeout={1}>
                   { this.state.msgs.map((msg, i) => {
                     const isFirst = (i === 0)

--- a/ui/less/com/hexagons.less
+++ b/ui/less/com/hexagons.less
@@ -457,6 +457,16 @@
       margin: -11px 1px -11px 0;
     }
   }
+
+  &.horizontal {
+    .user-hexagon {
+      width: 30px;
+      &:nth-child(even) {
+        position: relative;
+        top: 53px;
+      }
+    }
+  }
 }
 
 .user-hexagrid-80 {

--- a/ui/less/com/msg-thread.less
+++ b/ui/less/com/msg-thread.less
@@ -17,6 +17,15 @@
       display: none;
     }
   }
+  .recps-list {
+    height: 60px;
+    .user-pic img {
+      width: 60px;
+      height: 60px;
+      border-radius: 2px;
+      margin-right: 5px;
+    }
+  }
   // responsive-element query
   .width-gt500 {
     .items {


### PR DESCRIPTION
Updates the thread UI to show recipients in threads, via their profile pics.
![screen shot 2016-01-06 at 2 00 26 pm](https://cloud.githubusercontent.com/assets/1270099/12156373/4db42b6a-b490-11e5-98e9-bffec7fe2ce5.png)

I tried this with hexagons, but the spacing is just really rough. Anybody have ideas how I could do it?

![screen shot 2016-01-06 at 1 49 00 pm](https://cloud.githubusercontent.com/assets/1270099/12156383/5dd5db4c-b490-11e5-9786-b18f371fb275.png)
