### PR TITLE
ui: return to the inline composer

### DIFF
--- a/ui/com/composer/card.jsx
+++ b/ui/com/composer/card.jsx
@@ -28,7 +28,7 @@ export default class ComposerCard extends React.Component {
       <div className="left-meta"><UserPic id={app.user.id} /></div>
       { this.state.isOpen ?
         <Composer {...this.props} onSend={this.onSend.bind(this)} /> :
-        <div className="composer placeholder" onClick={this.onClick.bind(this)}>{this.props.placeholder}</div> }
+        <div className="composer placeholder" onClick={this.onClick.bind(this)}>{this.props.placeholder||'Write your message here'}</div> }
     </div>
   }
 }

--- a/ui/com/composer/index.jsx
+++ b/ui/com/composer/index.jsx
@@ -73,7 +73,7 @@ export default class Composer extends React.Component {
     this.state = {
       isPreviewing: false,
       isSending: false,
-      isPublic: false,
+      isPublic: this.props.isPublic || false,
       channel: this.props.channel,
       hasAddedFiles: false, // used to display a warning if a file was added in public mode, then they switch to private
       addedFileMeta: {}, // map of file hash -> metadata
@@ -304,7 +304,7 @@ export default class Composer extends React.Component {
       if (!props.isPublic) {
         if (props.isReply)
           return <span/>
-        return <a className="btn disabled"><i className="fa fa-paperclip" /> Attachments are not yet available in private messages</a>
+        return <a className="btn disabled"><i className="fa fa-paperclip" /> Attachments not available in PMs</a>
       }
       if (props.isAdding)
         return <a className="btn disabled"><i className="fa fa-paperclip" /> Adding...</a>
@@ -333,13 +333,20 @@ export default class Composer extends React.Component {
           : <ComposerRecps isReadOnly={this.isReply()} recps={this.state.recps} onAdd={this.onAddRecp.bind(this)} onRemove={this.onRemoveRecp.bind(this)} /> }
       </div>
     } else {
-      toolbarBottom = <div className="composer-ctrls flex" style={{ borderBottomColor: '#ccc', borderTop: 0 }}>
-        <AudienceBtn canChange={!this.isReply()} isPublic={this.isPublic()} onSelect={this.onSelectPublic.bind(this)} />
-        <AttachBtn isPublic={this.isPublic()} isReply={this.isReply()} hasAdded={this.state.hasAddedFiles} isAdding={this.state.isAddingFiles} onAttach={this.onAttach.bind(this)} />
-        <div className="flex-fill" />
-        <a className="btn" onClick={setPreviewing(true)}>Preview</a>
-        <SendBtn canSend={this.canSend() && !this.state.isSending} />
-      </div>      
+      toolbarBottom = <div>
+        <div className="composer-ctrls flex" style={{ borderBottomColor: '#ccc', borderTop: 0 }}>
+          <AudienceBtn canChange={!this.isReply()} isPublic={this.isPublic()} onSelect={this.onSelectPublic.bind(this)} />
+          <AttachBtn isPublic={this.isPublic()} isReply={this.isReply()} hasAdded={this.state.hasAddedFiles} isAdding={this.state.isAddingFiles} onAttach={this.onAttach.bind(this)} />
+          <div className="flex-fill" />
+          <a className="btn" onClick={setPreviewing(true)}>Preview</a>
+          <SendBtn canSend={this.canSend() && !this.state.isSending} />
+        </div> 
+        { !this.isReply()
+          ? ( this.isPublic()
+            ? <ComposerChannel isReadOnly={this.isReply()} onChange={this.onChangeChannel.bind(this)} value={this.getChannel()} />
+            : <ComposerRecps isReadOnly={this.isReply()} recps={this.state.recps} onAdd={this.onAddRecp.bind(this)} onRemove={this.onRemoveRecp.bind(this)} /> )
+          : '' }
+      </div>
     }
 
     return <div className="composer">

--- a/ui/com/leftnav.jsx
+++ b/ui/com/leftnav.jsx
@@ -24,6 +24,15 @@ export default class LeftNav extends React.Component {
     app.removeListener('update:indexCounts', this.refresh)
   }
 
+  static Heading (props) {
+    return <div className="leftnav-heading">{props.children}</div>
+  }
+  static Link (props) {
+    return <div className={'leftnav-link '+(props.className||'')+(props.pathname === props.to ? ' selected' : '')}>
+      <Link to={props.to}>{props.children}</Link>
+    </div>
+  }
+
   render() {
     const pathname = this.props.location && this.props.location.pathname
 
@@ -34,27 +43,18 @@ export default class LeftNav extends React.Component {
     const pinnedChannels = this.state.channels.filter(isPinned(true))
 
     // render
-    const NavHeading = props => {
-      return <div className="leftnav-heading">{props.children}</div>
-    }
-    const NavLink = props => {
-      return <div className={'leftnav-link '+(props.className||'')+(pathname === props.to ? ' selected' : '')}>
-        <Link to={props.to}>{props.children}</Link>
-      </div>
-    }
-    const renderChannel = c => <NavLink key={c.name} to={'/newsfeed/channel/'+c.name}><i className="fa fa-hashtag" /> {c.name}</NavLink>
+    const renderChannel = c => <LeftNav.Link pathname={pathname} key={c.name} to={'/newsfeed/channel/'+c.name}><i className="fa fa-hashtag" /> {c.name}</LeftNav.Link>
     return <div className="leftnav">
-      <NavLink className="compose-btn" to="/composer">Compose</NavLink>
-      <NavLink to="/"><i className="fa fa-bullhorn" /> Public</NavLink>
-      <NavLink to="/inbox"><i className="fa fa-inbox" /> Private ({this.state.indexCounts.inboxUnread})</NavLink>
-      <NavLink to="/bookmarks"><i className="fa fa-bookmark" /> Bookmarked ({this.state.indexCounts.bookmarksUnread})</NavLink>
-      <NavLink to="/sync"><i className="fa fa-users" /> People</NavLink>
+      <LeftNav.Link pathname={pathname} to="/"><i className="fa fa-bullhorn" /> Public</LeftNav.Link>
+      <LeftNav.Link pathname={pathname} to="/inbox"><i className="fa fa-inbox" /> Private ({this.state.indexCounts.inboxUnread})</LeftNav.Link>
+      <LeftNav.Link pathname={pathname} to="/bookmarks"><i className="fa fa-bookmark" /> Bookmarked ({this.state.indexCounts.bookmarksUnread})</LeftNav.Link>
+      <LeftNav.Link pathname={pathname} to="/sync"><i className="fa fa-users" /> People</LeftNav.Link>
       <Issues/>
-      { this.props.children ? <NavHeading>{this.props.title||'This Page'}</NavHeading> : '' }
+      { this.props.children ? <LeftNav.Heading>{this.props.title||'This Page'}</LeftNav.Heading> : '' }
       { this.props.children }
-      <NavHeading>Channels</NavHeading>
+      <LeftNav.Heading>Channels</LeftNav.Heading>
       { pinnedChannels.map(renderChannel) }
-      <NavLink to="/channels">Find more...</NavLink>
+      <LeftNav.Link pathname={pathname} to="/channels">Find more...</LeftNav.Link>
     </div>
   }
 }

--- a/ui/less/com/composer/card.less
+++ b/ui/less/com/composer/card.less
@@ -4,6 +4,8 @@
   margin: 10px auto;
   transition: max-height 0.2s;
   max-height: 70px;
+  position: relative;
+  left: -20px;
 
   &.open {
     max-height: 300px;
@@ -11,7 +13,6 @@
 
   .left-meta {
     flex: 0 0 74px;
-    padding: 2px 0 0 3px;
     img {
       width: 60px;
       margin: 2px;
@@ -26,7 +27,13 @@
       font-family: @content-font;
       padding: 10px;
       color: #aaa;
+      background: #fff;
       font-weight: 300;
+      border: 1px solid #ccc;
+    }
+
+    .composer-content {
+      margin-top: 0;
     }
   }
 }

--- a/ui/less/com/leftnav.less
+++ b/ui/less/com/leftnav.less
@@ -1,5 +1,6 @@
 .leftnav {
   flex: 0 0 175px;
+  margin-top: 5px;
   
   .leftnav-heading {
     margin: 15px 0 5px 10px;

--- a/ui/views/bookmarks.jsx
+++ b/ui/views/bookmarks.jsx
@@ -1,5 +1,6 @@
 'use babel'
 import React from 'react'
+import { Link } from 'react-router'
 import pull from 'pull-stream'
 import mlib from 'ssb-msgs'
 import { LocalStoragePersistedComponent } from '../com'
@@ -45,6 +46,7 @@ export default class Bookmarks extends LocalStoragePersistedComponent {
 
     const Toolbar = props => {    
       return <div className="flex light-toolbar">
+        <Link to="/bookmarks"><i className="fa fa-bookmark" /> Bookmarked Threads</Link>
         <div className="flex-fill"/>
         <a onClick={this.onMarkAllRead.bind(this)}><i className="fa fa-check-square" /> Mark All Read</a>
         <DropdownBtn items={LISTITEMS} right onSelect={this.onSelectMsgView.bind(this)}>{listItem.label}</DropdownBtn>

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -1,5 +1,6 @@
 'use babel'
 import React from 'react'
+import { Link } from 'react-router'
 import pull from 'pull-stream'
 import mlib from 'ssb-msgs'
 import { LocalStoragePersistedComponent } from '../com'
@@ -45,6 +46,7 @@ export default class Inbox extends LocalStoragePersistedComponent {
 
     const Toolbar = props => {    
       return <div className="flex light-toolbar">
+        <Link to="/inbox"><i className="fa fa-inbox" /> Private Threads</Link>
         <div className="flex-fill"/>
         <a onClick={this.onMarkAllRead.bind(this)}><i className="fa fa-check-square" /> Mark All Read</a>
         <DropdownBtn items={LISTITEMS} right onSelect={this.onSelectMsgView.bind(this)}>{listItem.label}</DropdownBtn>
@@ -57,6 +59,7 @@ export default class Inbox extends LocalStoragePersistedComponent {
         ref="list"
         threads
         dateDividers
+        composer composerProps={{ isPublic: false }}
         Hero={Toolbar}
         ListItem={ListItem} listItemProps={{ userPic: true }}
         LeftNav={LeftNav} leftNavProps={{location: this.props.location}}

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -99,7 +99,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
       return <div className="flex light-toolbar">
         { channel
           ? <Link to={`/newsfeed/channel/${channel}`}>#{channel}</Link>
-          : '' }
+          : <Link to="/"><i className="fa fa-bullhorn" /> Public Threads</Link> }
         { channel
           ? <a onClick={this.onTogglePinned.bind(this)}><i className="fa fa-thumb-tack" /> {isPinned?"Unpin Channel":"Pin Channel"}</a>
           : '' }
@@ -118,6 +118,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
         threads
         dateDividers
         openMsgEvent
+        composer composerProps={{ isPublic: true, channel: channel }}
         filter={filter}
         Hero={Toolbar}
         LeftNav={LeftNav} leftNavProps={{location: this.props.location}}


### PR DESCRIPTION
Per feedback from the team, I restored the inline composer. The code for the composer page is still there, but it's 

![screen shot 2016-01-08 at 3 31 28 pm](https://cloud.githubusercontent.com/assets/1270099/12210197/e181cc38-b61d-11e5-9c38-1725aac1ac79.png)
