### PR TITLE
Desktop notifications

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -524,6 +524,10 @@ exports.init = function (sbot, opts) {
       var readPush = pushable()
       var read = pull(readPush, paramap(fetch))
 
+      // allow live-only stream
+      if (opts && opts.live === 'only')
+        readPush.end()
+      else
       // await sync, then emit the reads
       awaitSync(function () {
         var added = 0

--- a/api/index.js
+++ b/api/index.js
@@ -524,10 +524,6 @@ exports.init = function (sbot, opts) {
       var readPush = pushable()
       var read = pull(readPush, paramap(fetch))
 
-      // allow live-only stream
-      if (opts && opts.live === 'only')
-        readPush.end()
-      else
       // await sync, then emit the reads
       awaitSync(function () {
         var added = 0

--- a/ui/com/msg-view/notification.jsx
+++ b/ui/com/msg-view/notification.jsx
@@ -19,22 +19,8 @@ export default class Notification extends React.Component {
   }
 
   componentDidMount() {
-    // load the subject msg
-    const msg = this.props.msg
-    if (!msg || msg.value.content.type !== 'vote')
-      return this.setState({ subjectMsg: null }) // no subject msg needed
-
-    // `props.msg` is a vote, load the subject msg
-    const vote = mlib.link(msg.value.content.vote, 'msg')
-    if (!vote)
-      return this.setState({ subjectMsg: null }) // malformed
-
-    app.ssb.get(vote.link, (err, subjectMsg) => {
-      if (subjectMsg) {
-        subjectMsg = { key: vote.link, value: subjectMsg }
-        threadlib.decryptThread(app.ssb, subjectMsg, () => this.setState({ subjectMsg: subjectMsg }))
-      } else
-        this.setState({ subjectMsg: null })
+    u.getSubjectMessage(this.props.msg, (subjectMsg) => {
+      this.setState({ subjectMsg: subjectMsg })
     })
   }
 

--- a/ui/layout.jsx
+++ b/ui/layout.jsx
@@ -9,6 +9,7 @@ import FollowNearby from './com/forms/follow-nearby'
 import PubInvite from './com/forms/pub-invite'
 import SearchPalette from './com/search-palette'
 import FindBar from './com/findbar'
+import desktopNotifications from './lib/desktop-notifications'
 
 const SETUP_LABELS = [<i className="fa fa-user"/>, <i className="fa fa-wifi"/>, <i className="fa fa-cloud"/>]
 const SETUP_FORMS = [ProfileSetup, FollowNearby, PubInvite]
@@ -32,6 +33,8 @@ export default class Layout extends React.Component {
     app.on('modal:setup', isOpen => this.setState({ setupIsOpen: isOpen }))
     app.on('find:next', this.doFind.bind(this, true))
     app.on('find:previous', this.doFind.bind(this, false))
+
+    desktopNotifications.stream(app.ssb.patchwork.createNotificationsStream)
   }
   componentWillReceiveProps() {
     // update state on view changes

--- a/ui/lib/desktop-notifications.js
+++ b/ui/lib/desktop-notifications.js
@@ -11,11 +11,16 @@ exports.notify = function notify(opts) {
     Notification.requestPermission(notify.bind(this, opts))
 }
 
+function trimMessage(str) {
+  str = String(str)
+  return str.length > 140 ? str.substr(0, 140) + '⋯' : str
+}
+
 /* text taken from ui/com/msg-view/notification.jsx */
 
 var render = {
   post: function (msg, c, cb) {
-    var subject = c.text || 'a message'
+    var subject = trimMessage(c.text) || 'a message'
     var author = u.getName(msg.value.author)
     cb({
       title: author + ' mentioned you in ',
@@ -26,7 +31,7 @@ var render = {
   vote: function (msg, c, cb) {
     u.getSubjectMessage(msg, function (subject) {
       var text = (subject && subject.value.content &&
-                  subject.value.content.text || 'this message')
+                  trimMessage(subject.value.content.text) || 'this message')
       var author = u.getName(msg.value.author)
       if (typeof c.vote.value !== 'number')
         return null

--- a/ui/lib/desktop-notifications.js
+++ b/ui/lib/desktop-notifications.js
@@ -71,5 +71,8 @@ function notifyMsg(msg) {
 
 exports.stream = function (getNotifs) {
   if (window.Notification)
-    pull(getNotifs({live: 'only'}), pull.drain(notifyMsg))
+    pull(
+      getNotifs({ live: true, gt: [Date.now()] }),
+      pull.drain(notifyMsg)
+    )
 }

--- a/ui/lib/desktop-notifications.js
+++ b/ui/lib/desktop-notifications.js
@@ -1,0 +1,70 @@
+var pull = require('pull-stream')
+var u    = require('./util')
+var app  = require('./app')
+
+exports.notify = function notify(opts) {
+  if (!opts || !window.Notification)
+    return
+  if (Notification.permission == 'granted')
+    return new Notification(opts.title, opts)
+  if (Notification.permission != 'denied')
+    Notification.requestPermission(notify.bind(this, opts))
+}
+
+/* text taken from ui/com/msg-view/notification.jsx */
+
+var render = {
+  post: function (msg, c, cb) {
+    var subject = c.text || 'a message'
+    var author = u.getName(msg.value.author)
+    cb({
+      title: author + ' mentioned you in ',
+      body: subject
+    })
+  },
+
+  vote: function (msg, c, cb) {
+    u.getSubjectMessage(msg, function (subject) {
+      var text = (subject && subject.value.content &&
+                  subject.value.content.text || 'this message')
+      var author = u.getName(msg.value.author)
+      if (typeof c.vote.value !== 'number')
+        return null
+      var desc = (c.vote.value > 0) ? 'dug'
+        : (c.vote.value == 0) ? 'removed their vote for'
+        : 'flagged'
+      var reason = (c.vote.reason) ? (' as ' + c.vote.reason) : ''
+      cb({
+        title: author + ' ' + desc + ' ' + text + reason
+      })
+    })
+  },
+
+  contact: function (msg, c, cb) {
+    var name = u.getName(msg.value.author)
+    var title =
+      (c.following === true)  ? name + ' followed you' :
+      (c.blocking === true)   ? name + ' blocked you' :
+      (c.following === false) ? name + ' unfollowed you' :
+      null
+    cb(title && {title: title})
+  }
+}
+
+function notifyMsg(msg) {
+  var content = msg.value.content
+  var renderMsg = render[content.type]
+  if (renderMsg) {
+    renderMsg(msg, content, function (notif) {
+      if (notif) {
+        notif.icon = u.profilePicUrl(msg.value.author)
+        exports.notify(notif)
+      }
+    })
+  }
+}
+
+exports.stream = function (getNotifs) {
+  if (window.Notification)
+    pull(getNotifs({live: 'only'}), pull.drain(notifyMsg))
+}

--- a/ui/lib/util.js
+++ b/ui/lib/util.js
@@ -6,6 +6,7 @@ var multicb = require('multicb')
 var moment = require('moment')
 var app = require('./app')
 var social = require('./social-graph')
+var threadlib = require('patchwork-threads')
 
 exports.debounce = function (fn, wait) {
   var timeout
@@ -144,3 +145,23 @@ exports.getContactedPeerIds = function (peers) {
   }
 }
 
+exports.getSubjectMessage = function (msg, cb) {
+  // load the subject msg
+  if (!msg || msg.value.content.type !== 'vote')
+    return cb(null) // no subject msg needed
+
+  // `props.msg` is a vote, load the subject msg
+  var vote = mlib.link(msg.value.content.vote, 'msg')
+  if (!vote)
+    return cb(null) // malformed
+
+  app.ssb.get(vote.link, function (err, subjectMsg) {
+    if (subjectMsg) {
+      subjectMsg = { key: vote.link, value: subjectMsg }
+      threadlib.decryptThread(app.ssb, subjectMsg, function () {
+        cb(subjectMsg)
+      })
+    } else
+      cb(null)
+  })
+}


### PR DESCRIPTION
This patch integrates desktop notifications. A notification is shown for each new thing that currently appears in the notifications sidebar. ~~To help with doing this, we also add a live-only option to the patchwork API methods that create streams, so that only new/live items get processed for showing notifications.~~

Other ideas:
- Add a UI settings option to enable/disable desktop notifications
- Notify in response to new direct mail, or replies to bookmarked threads, as proposed in #114 