### PR TITLE
Newsfeed and inbox improvements

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -550,7 +550,7 @@ exports.init = function (sbot, opts) {
           if (limit && added >= limit)
             break
 
-          // we're going to only look at timestamp, because that's all that phoenix cares about
+          // we're going to only look at timestamp, because that's all that the index tracks
           var invalid = !!(
             (lt  && row.ts >= lt[0]) ||
             (lte && row.ts > lte[0]) ||

--- a/ui/views/bookmarks.jsx
+++ b/ui/views/bookmarks.jsx
@@ -1,8 +1,6 @@
 'use babel'
 import React from 'react'
 import { Link } from 'react-router'
-import pull from 'pull-stream'
-import mlib from 'ssb-msgs'
 import { LocalStoragePersistedComponent } from '../com'
 import LeftNav from '../com/leftnav'
 import DropdownBtn from '../com/dropdown'

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -1,8 +1,7 @@
 'use babel'
 import React from 'react'
 import { Link } from 'react-router'
-import pull from 'pull-stream'
-import mlib from 'ssb-msgs'
+import threadlib from 'patchwork-threads'
 import { LocalStoragePersistedComponent } from '../com'
 import LeftNav from '../com/leftnav'
 import DropdownBtn from '../com/dropdown'
@@ -29,8 +28,11 @@ export default class Inbox extends LocalStoragePersistedComponent {
   }
 
   cursor (msg) {
-    if (msg)
+    if (msg) {
+      // find the last post (inbox is ordered by timestamp of last post in thread)
+      var last = threadlib.getLastThreadPost(msg)
       return [msg.value.timestamp, msg.value.author]
+    }
   }
 
   onSelectMsgView(v, index) {

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -11,6 +11,7 @@ import Card from '../com/msg-view/card'
 import Oneline from '../com/msg-view/oneline'
 import Summary from '../com/msg-view/summary'
 import app from '../lib/app'
+import social from '../lib/social-graph'
 
 const LISTITEMS = [
   { label: <span><i className="fa fa-list"/> View: Inline</span>, Component: Card },
@@ -66,7 +67,12 @@ export default class Inbox extends LocalStoragePersistedComponent {
         live={{ gt: [Date.now(), null] }}
         emptyMsg="Your inbox is empty."
         source={app.ssb.patchwork.createInboxStream}
+        filter={followedOnlyFilter}
         cursor={this.cursor} />
     </div>
   }
+}
+
+function followedOnlyFilter (msg) {
+  return msg.value.author === app.user.id || social.follows(app.user.id, msg.value.author)
 }

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router'
 import pull from 'pull-stream'
 import mlib from 'ssb-msgs'
 import cls from 'classnames'
+import threadlib from 'patchwork-threads'
 import { LocalStoragePersistedComponent } from '../com'
 import LeftNav from '../com/leftnav'
 import DropdownBtn from '../com/dropdown'
@@ -80,16 +81,16 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
 
     // msg-list params
     const cursor = msg => {
-      if (msg)
-        return [msg.value.timestamp, msg.value.author]
+      if (msg) {
+        // find the last post (newsfeed is ordered by timestamp of last post in thread)
+        var last = threadlib.getLastThreadPost(msg)
+        return [last.value.timestamp, last.value.author]
+      }
     }
     const source = (opts) => {
       if (channel) 
         return app.ssb.patchwork.createChannelStream(channel, opts)
       return app.ssb.patchwork.createNewsfeedStream(opts)
-    }
-    const filter = msg => {
-      return followedOnlyFilter(msg)
     }
 
     const Toolbar = props => {    
@@ -117,7 +118,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
         dateDividers
         openMsgEvent
         composer composerProps={{ isPublic: true, channel: channel }}
-        filter={filter}
+        filter={followedOnlyFilter}
         Hero={Toolbar}
         LeftNav={LeftNav} leftNavProps={{location: this.props.location}}
         ListItem={ListItem} listItemProps={{ userPic: true }}

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -89,9 +89,7 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
       return app.ssb.patchwork.createNewsfeedStream(opts)
     }
     const filter = msg => {
-      if (this.state.isFollowedOnly)
-        return followedOnlyFilter(msg)
-      return true
+      return followedOnlyFilter(msg)
     }
 
     const Toolbar = props => {    


### PR DESCRIPTION
2 updates:
 - filter inbox and newsfeed to posts by followed users only
 - fix: newsfeed and inbox no longer accidentally skip chunks of the index