### PR TITLE
add build-release script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "start": "node ./index.js",
     "test": "set -e; for t in api/test/*.js; do node $t; done",
+    "build-release": "NODE_ENV=production npm run build",
     "build": "npm run build:js && npm run build:css",
     "build:ui": "npm run build:js && npm run build:css",
     "build:js": "node ./scripts/build.js ./ui/main.js ./ui/main.build.js",
     "build:css": "mkdir -p ./ui/css && lessc ./ui/less/main.less --autoprefix ./ui/css/main.css",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build-release"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "?",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "url": "https://github.com/ssbc/patchwork.git"
   },
   "scripts": {
+    "build-release": "npm run build-release:js && npm run build-release:css",
+    "build-release:js": "NODE_ENV=production node ./scripts/build.js ./ui/main.js ./ui/main.build.js",
+    "build-release:css": "mkdir -p ./ui/css && lessc ./ui/less/main.less --autoprefix ./ui/css/main.css",
+    "build": "npm run build:js && npm run build:css",
+    "build:js": "node ./scripts/build.js ./ui/main.js ./ui/main.build.js",
+    "build:css": "mkdir -p ./ui/css && lessc ./ui/less/main.less ./ui/css/main.css",
     "start": "node ./index.js",
     "test": "set -e; for t in api/test/*.js; do node $t; done",
-    "build-release": "NODE_ENV=production npm run build",
-    "build": "npm run build:js && npm run build:css",
-    "build:ui": "npm run build:js && npm run build:css",
-    "build:js": "node ./scripts/build.js ./ui/main.js ./ui/main.build.js",
-    "build:css": "mkdir -p ./ui/css && lessc ./ui/less/main.less --autoprefix ./ui/css/main.css",
     "prepublish": "npm run build-release"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",


### PR DESCRIPTION
This adds `npm run build-release`, which produces release-version assets.

Per https://github.com/ssbc/patchwork/issues/173, this includes setting `NODE_ENV` to production, which causes faster rendering in runtime (yay!)

@clehner did you have css build stuff to add here?