### PR TITLE
fix: a bunch of style updates to solve flexboxes going too wide

### DIFF
--- a/ui/com/msg-content.jsx
+++ b/ui/com/msg-content.jsx
@@ -30,7 +30,7 @@ export class Inline extends React.Component {
     let c = this.props.msg.value.content
 
     if (this.props.forceRaw)
-      return <DivRaw key={this.props.msg.key} obj={c} />
+      return <div>{JSON.stringify(c)}</div>
 
     try {
       switch (c.type) {
@@ -40,6 +40,6 @@ export class Inline extends React.Component {
       }
     } catch (e) { console.warn(e) }
 
-    return <DivRaw key={this.props.msg.key} obj={c} />
+    return <div>{JSON.stringify(c)}</div>
   }
 }

--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -365,7 +365,7 @@ export default class MsgList extends React.Component {
           isInfiniteLoading={this.state.isLoading}>
           <div className="flex">
             { LeftNav ? <LeftNav {...this.props.leftNavProps} /> : '' }
-            <div className="flex-fill" style={{padding: '5px'}}>
+            <div className="flex-fill">
               { Hero ? <Hero/> : '' }
               { nQueued ?
                 <a className="new-msg-queue" onClick={this.reload.bind(this)}>{nQueued} new update{u.plural(nQueued)}</a>

--- a/ui/less/com/msg-view/oneline.less
+++ b/ui/less/com/msg-view/oneline.less
@@ -1,5 +1,6 @@
 .msg-view.oneline {
   display: flex;
+  flex-wrap: wrap;
   height: 32px;
   padding: 8px 6px 6px;
   overflow: hidden;
@@ -33,9 +34,7 @@
   }
   .content {
     flex: 1;
-    white-space: pre;
     overflow: hidden;
-    text-overflow: ellipsis;
     color: @dark-gray3;
     font-family: Helvetica;
     font-weight: 300;

--- a/ui/less/helpers.less
+++ b/ui/less/helpers.less
@@ -3,6 +3,7 @@
 }
 .flex-fill {
   flex: 1;
+  max-width: 100%;
 }
 
 .loading {

--- a/ui/less/layout.less
+++ b/ui/less/layout.less
@@ -15,4 +15,5 @@ html, body {
 
 #mainview {
   flex: 1;
+  max-width: 100%;
 }

--- a/ui/less/views/rightnav.less
+++ b/ui/less/views/rightnav.less
@@ -11,6 +11,9 @@
       text-align: center;
     }
   }
+  .msg-view {
+    width: 300px;
+  }
   .msg-view.summary .body .body-line {
     -webkit-line-clamp: 3;
   }


### PR DESCRIPTION
Seems that newer browsers changed their interpretation of flex-boxes somehow, and that caused a bunch of width overflows. This solves it.