### PR TITLE
styles: wider messages

### DIFF
--- a/ui/less/com/composer.less
+++ b/ui/less/com/composer.less
@@ -76,7 +76,6 @@
       resize: none;
       border: 0;
       min-height: 140px;
-      max-width: 586px; // mimics the rendered cards
       padding: 10px;
       margin: 0;
 

--- a/ui/less/com/composer/card.less
+++ b/ui/less/com/composer/card.less
@@ -1,6 +1,6 @@
 .composer-card {
   display: flex;
-  max-width: 660px;
+  max-width: 760px;
   margin: 10px auto;
   transition: max-height 0.2s;
   max-height: 70px;

--- a/ui/less/com/msg-thread.less
+++ b/ui/less/com/msg-thread.less
@@ -3,12 +3,16 @@
   .items {
     position: relative;
     padding: 0 5px 100px;
-    .msg-view.card-post .left-meta {
-      display: none;
+    .msg-view.card-post {
+      margin-top: 2px;
+      margin-bottom: 2px;
+      .left-meta {
+        display: none;
+      }
     }
   }
   .container {
-    max-width: 660px;
+    max-width: 760px;
     margin: 0px auto;
   }
   .composer {

--- a/ui/less/com/msg-view/card.less
+++ b/ui/less/com/msg-view/card.less
@@ -1,6 +1,6 @@
 .msg-view.card-post {
   display: flex;
-  max-width: 660px;
+  max-width: 760px;
   margin: 10px auto;
 
   .left-meta {
@@ -159,7 +159,7 @@
 }
 
 .msg-view.card-missing-post {
-  max-width: 660px;
+  max-width: 760px;
   margin: 20px auto;
 
   div {
@@ -176,7 +176,7 @@
 }
 
 .msg-view.card-mention {
-  max-width: 660px;
+  max-width: 760px;
   margin: 20px auto;
 
   &>div {
@@ -201,7 +201,7 @@
 
 .msg-view.card-muted {
   display: flex;
-  max-width: 660px;
+  max-width: 760px;
   margin: 20px auto;
 
   .ctrls {


### PR DESCRIPTION
Messages seem a little narrow to me, leaving a lot of blank space where we could have content. This PR goes from this:

![screen shot 2016-01-22 at 12 49 59 pm](https://cloud.githubusercontent.com/assets/1270099/12519878/f4276688-c106-11e5-9225-7a16860e6f08.png)

To this:

![screen shot 2016-01-22 at 12 49 10 pm](https://cloud.githubusercontent.com/assets/1270099/12519884/fe08683c-c106-11e5-8309-54d537906ccc.png)

And also closes the gaps between messages inside a thread:

![screen shot 2016-01-22 at 12 49 13 pm](https://cloud.githubusercontent.com/assets/1270099/12519892/07865d92-c107-11e5-9ff9-c63c3ed0bb17.png)
