### PR TITLE
fix: use the index-row ts in view cursors, this works more consistently

### DIFF
--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -28,11 +28,8 @@ export default class Inbox extends LocalStoragePersistedComponent {
   }
 
   cursor (msg) {
-    if (msg) {
-      // find the last post (inbox is ordered by timestamp of last post in thread)
-      var last = threadlib.getLastThreadPost(msg)
-      return [last.value.timestamp, last.value.author]
-    }
+    if (msg)
+      return [msg.ts, false]
   }
 
   onSelectMsgView(v, index) {

--- a/ui/views/newsfeed.jsx
+++ b/ui/views/newsfeed.jsx
@@ -86,11 +86,8 @@ export default class NewsFeed extends LocalStoragePersistedComponent {
 
     // msg-list params
     const cursor = msg => {
-      if (msg) {
-        // find the last post (newsfeed is ordered by timestamp of last post in thread)
-        var last = threadlib.getLastThreadPost(msg)
-        return [last.value.timestamp, last.value.author]
-      }
+      if (msg)
+        return [msg.ts, false]
     }
     const filter = msg => {
       if (this.state.showFoaf)


### PR DESCRIPTION
Fixes a bug where messages with a clock-skew would sometimes be used as the "cursor" for fetching the next message, causing a bad fetch (eg getting messages that have already been fetched). Basically this was a bug in my logic.