### PR TITLE
Fix case

### DIFF
--- a/ui/com/stepped-progress-bar.jsx
+++ b/ui/com/stepped-progress-bar.jsx
@@ -1,6 +1,6 @@
 'use babel'
 import React from 'react'
-import cls from 'classNames'
+import cls from 'classnames'
 
 function mkarray(n) {
   var arr = []


### PR DESCRIPTION
This is a fix for:
```
Error: Cannot find module 'classNames' from '/usr/local/src/patchwork/ui/com'
```