### PR TITLE
Electron fixes

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -1,8 +1,8 @@
 var Menu = require('electron').Menu
 var dialog = require('electron').dialog
-var nativeImage = require('electron').nativeImage
 var pkg = require('../package')
 var windows = require('./windows')
+var path = require('path')
 
 var isMac = (process.platform == 'darwin')
 
@@ -11,7 +11,7 @@ function showAbout(win) {
     title: 'About Patchwork',
     buttons: ['Close', 'License'],
     type: 'info',
-    icon: nativeImage.createFromPath('ui/img/icon.png'),
+    icon: path.join(__dirname, '../ui/img/icon.png'),
     message: pkg.name + ' v' + pkg.version,
     detail: pkg.description + '\n\n' +
       'Copyright © 2015-2016 Secure Scuttlebutt Consortium\n\n' +

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -1,5 +1,6 @@
 var Menu = require('electron').Menu
 var dialog = require('electron').dialog
+var nativeImage = require('electron').nativeImage
 var pkg = require('../package')
 var windows = require('./windows')
 
@@ -10,10 +11,11 @@ function showAbout(win) {
     title: 'About Patchwork',
     buttons: ['Close', 'License'],
     type: 'info',
-    icon: 'assets/icon.png',
+    icon: nativeImage.createFromPath('ui/img/icon.png'),
     message: pkg.name + ' v' + pkg.version,
     detail: pkg.description + '\n\n' +
-      'Copyright © 2015-2016 Secure Scuttlebutt Consortium'
+      'Copyright © 2015-2016 Secure Scuttlebutt Consortium\n\n' +
+      'http://ssbc.github.io/patchwork/'
   }, function (btn) {
     if (btn == 1)
       showLicense(win)

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -247,7 +247,7 @@ module.exports = function (configOracle) {
         }
       ]
     },
-    isMac ? {
+    {
       label: 'Window',
       submenu: [
         {
@@ -265,6 +265,7 @@ module.exports = function (configOracle) {
             win.close()
           }
         },
+      ].concat(isMac ? [
         {
           label: 'Minimize',
           accelerator: 'CmdOrCtrl+M',
@@ -278,8 +279,8 @@ module.exports = function (configOracle) {
           selector: 'arrangeInFront:',
           role: 'front'
         }
-      ]
-    } : {}
+      ] : [])
+    }
   ]
 
   menu = Menu.buildFromTemplate(template)


### PR DESCRIPTION
- Show Window menu
- Fix About window missing image
- Add link to website in About window

~~For some reason, when I build a package using the patchwork-electron release scripts, the image in the About window is not recognized and was giving me an error, unless I ran the executable in the directory of patchwork. However, by wrapping the image path with nativeImage(), the error is suppresed and a generic icon is used instead, which fixes that problem partially.~~ Edit: Fixed in 3758bc0; nativeImage() not needed.