### PR TITLE
Make post date a link to the post

### DIFF
--- a/ui/com/msg-view/card.jsx
+++ b/ui/com/msg-view/card.jsx
@@ -246,7 +246,7 @@ export default class Card extends React.Component {
       <div className="content">
         <div className="header">
           <div className="header-left">
-            <UserLink id={msg.value.author} /> <span className="date"><NiceDate ts={msg.value.timestamp} /></span>
+            <UserLink id={msg.value.author} /> <Link className="date" to={'/msg/'+encodeURIComponent(msg.key)}><NiceDate ts={msg.value.timestamp} /></Link>
           </div>
           <div className="header-right">
             { !this.props.noBookmark ? <BookmarkBtn isBookmarked={msg.isBookmarked} onClick={()=>this.props.onToggleBookmark(msg)} /> : '' }


### PR DESCRIPTION
This patch makes the date text on a post be a link to the post. This makes it easier to get a link to a post. It also makes it possible to navigate to a thread/post from the search results.