### PR TITLE
add right-padding to markdown table cells

### DIFF
--- a/ui/less/com/markdown.less
+++ b/ui/less/com/markdown.less
@@ -29,4 +29,8 @@
     cursor: default;
     text-decoration: none;
   }
+
+  td, th {
+    padding: 0 6px 0 0;
+  }
 }


### PR DESCRIPTION
Before:
![selection_286](https://cloud.githubusercontent.com/assets/2665886/13544239/aeaa4f78-e2d8-11e5-88cb-177b8d256b85.png)

---

After:
![selection_285](https://cloud.githubusercontent.com/assets/2665886/13544240/aead3058-e2d8-11e5-8cb5-64c504f78806.png)

... just a little bit less cluttered. In particular the table headers, which would no longer need that '/' hack to not look like a mess