### PR TITLE
remove incorrect version number

### DIFF
--- a/ui/main.html
+++ b/ui/main.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Patchwork v2 rc1</title>
+    <title>Patchwork</title>
     <meta charset="utf-8">
 
     <link rel="shortcut icon" type="image/png" href="./img/icon.png"/>


### PR DESCRIPTION
This is a bit annoying each time i see it );
should either show the correct version number or do not mention the version number at all.