### PR TITLE
Put unread count in favicon

### DIFF
--- a/ui/lib/app.js
+++ b/ui/lib/app.js
@@ -17,6 +17,7 @@ var SSBClient = require('./ws-client')
 var emojis    = require('emoji-named-characters')
 var Emitter   = require('events')
 var extend    = require('xtend/mutable')
+var favicon   = require('./favicon')
 var createHashHistory = require('history').createHashHistory
 
 // event streams and listeners
@@ -162,8 +163,10 @@ function pollPeers () {
 }
 
 function updateTitle () {
-  document.title = '('+app.indexCounts.inboxUnread+') Patchwork'
+  // document.title = '('+app.indexCounts.inboxUnread+') Patchwork'
+  favicon.update({ label: app.indexCounts.inboxUnread })
 }
+window.favicon = favicon
 
 function fetchLatestState (cb) {
   if (!patchworkEventStream)

--- a/ui/lib/favicon.js
+++ b/ui/lib/favicon.js
@@ -1,0 +1,90 @@
+const ICON_PATH = '/img/icon.png'
+const FONT = 'Helvetica, Arial, sans-serif'
+var canvas = document.createElement('canvas')
+var img = null
+var label = false
+
+module.exports.update = function (opts) {
+  if ('label' in opts) {
+    if (typeof opts.label == 'number' && opts.label > 0 && opts.label < 10)
+      label = ' '+opts.label
+    else
+      label = opts.label
+  }
+  loadImg(draw)
+}
+
+function draw () {
+  var head = document.getElementsByTagName('head')[0]
+  var favicon = document.querySelector('link[rel=icon]')
+  var newFavicon = document.createElement('link')
+  var multiplier, fontSize, context, xOffset, yOffset, border, shadow
+
+  // scale canvas elements based on favicon size
+  multiplier = img.width / 16
+  fontSize   = multiplier * 11
+  xOffset    = multiplier
+  yOffset    = multiplier * 11
+  border     = multiplier
+  shadow     = multiplier * 2
+
+  canvas.height = canvas.width = img.width
+  context = canvas.getContext('2d')
+  context.font = 'bold ' + fontSize + 'px ' + FONT
+
+  // draw favicon background
+  if (label) { context.globalAlpha = 0.5 }
+  context.drawImage(img, 0, 0)
+  context.globalAlpha = 1.0
+
+  if (label) {
+    // draw white drop shadow
+    context.shadowColor = '#FFF'
+    context.shadowBlur = shadow
+    context.shadowOffsetX = 0
+    context.shadowOffsetY = 0
+
+    // draw white border
+    context.fillStyle = '#FFF'
+    context.fillText(label, xOffset, yOffset)
+    context.fillText(label, xOffset + border, yOffset)
+    context.fillText(label, xOffset, yOffset + border)
+    context.fillText(label, xOffset + border, yOffset + border)
+
+    // draw black label
+    context.fillStyle = '#000'
+    context.fillText(label,
+      xOffset + (border / 2.0),
+      yOffset + (border / 2.0)
+    )
+  }
+
+  // replace favicon with new favicon
+  newFavicon.rel = 'icon'
+  newFavicon.href = canvas.toDataURL('image/png')
+  if (favicon) { head.removeChild(favicon) }
+  head.appendChild(newFavicon)
+}
+
+var loadImgCbs
+function loadImg (cb) {
+  // already loaded?
+  if (img)
+    return cb() // go
+
+  // queue active?
+  if (loadImgCbs)
+    return loadImgCbs.push(cb) // add to queue
+
+  // start the queue
+  loadImgCbs = [cb]
+
+  // load image
+  img = document.createElement('img')
+  img.crossOrigin = 'anonymous'
+  img.onload = () => {
+    loadImgCbs.forEach(cb => cb())
+    loadImgCbs = null
+  }
+  img.src = ICON_PATH
+}

--- a/ui/main.html
+++ b/ui/main.html
@@ -4,7 +4,7 @@
     <title>Patchwork</title>
     <meta charset="utf-8">
 
-    <link rel="shortcut icon" type="image/png" href="./img/icon.png"/>
+    <link rel="icon" type="image/png" href="./img/icon.png"/>
     <link rel="stylesheet" type="text/css" href="./css/fontawesome.min.css">
     <link rel="stylesheet" type="text/css" href="./css/hint.min.css">
     <link rel="stylesheet" type="text/css" href="./css/main.css">


### PR DESCRIPTION
This PR moves the unread count from the document title to the favicon, which means you can pin the tab and stay abreast of new messages.

![screen shot 2016-03-12 at 12 22 19 pm](https://cloud.githubusercontent.com/assets/1270099/13724491/284d13be-e84d-11e5-9c25-67202a8b9124.png)
