### PR TITLE
Add home view, with merged inbox and activity feed

### DIFF
--- a/ui/com/leftnav.jsx
+++ b/ui/com/leftnav.jsx
@@ -100,7 +100,7 @@ export default class LeftNav extends React.Component {
       <Issues/>
       { this.state.isChannelListOpen ? <ChannelList channels={this.state.channels} onSelect={this.onSelectChannel.bind(this)} /> : '' }
       
-      <LinkGroup pathname={pathname} to="/" label={<strong>Inbox ({app.indexCounts.inboxUnread})</strong>} icon="inbox" group="inbox">
+      <LinkGroup pathname={pathname} to="/inbox" label={`Inbox (${app.indexCounts.inboxUnread})`} icon="inbox" group="inbox">
         <LeftNav.Link pathname={pathname} to="/inbox/private">Private ({app.indexCounts.privateUnread})</LeftNav.Link>
         <LeftNav.Link pathname={pathname} to="/inbox/watching">Watching ({app.indexCounts.bookmarkUnread})</LeftNav.Link>
         <LeftNav.Link pathname={pathname} to="/inbox/mentions">Mentioned ({app.indexCounts.mentionUnread})</LeftNav.Link>

--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -432,13 +432,13 @@ export default class MsgList extends React.Component {
           <div className="flex" style={{position: 'relative'}}>
             { LeftNav ? <LeftNav {...this.props.leftNavProps} /> : '' }
             <div className="flex-fill">
+              { this.props.noTopNav ? '' : <TopNav searchQuery={this.props.searchQuery} composer={this.props.composer} composerProps={this.props.composerProps} {...this.props.topNavProps} /> }
               { Hero ? <Hero/> : '' }
-              { this.props.noTopNav ? '' : <TopNav searchQuery={this.props.searchQuery} contentTypes={this.props.contentTypes} composer={this.props.composer} composerProps={this.props.composerProps} {...this.props.topNavProps} /> }
               { nQueued ?
                 <a className="new-msg-queue" onClick={this.reload.bind(this)}>{nQueued} new update{u.plural(nQueued)}</a>
                 : '' }
               { this.state.msgs.length === 0 && this.state.isLoading ? <div style={{fontWeight: 300, textAlign: 'center'}}>Loading...</div> : '' }
-              { isEmpty ?
+              { isEmpty && (this.props.emptyMsg !== false) ?
                 <div className="empty-msg">
                   { (this.props.emptyMsg || 'No messages.') }
                 </div>

--- a/ui/com/msg-list/simple.jsx
+++ b/ui/com/msg-list/simple.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import MsgList from '../msg-list'
+import Summary from '../msg-view/summary'
+import Thread from '../msg-thread'
+import ResponsiveElement from '../responsive-element'
+
+export default class SimpleMsgList extends MsgList {
+  render() {
+    const ListItem = this.props.ListItem || Summary
+    const isEmpty = (!this.state.isLoading && this.state.msgs.length === 0)
+
+    // render messages here, into an array, so we can insert date dividers
+    var listEls = []
+    this.state.msgs.forEach((m, i) => {
+      // missing value?
+      if (!m.value)
+        return // dont render
+
+      // render item
+      if (m.isOpened) {
+        listEls.push(
+          <Thread
+            key={m.key}
+            id={m.key}
+            onMsgChange={this.handlers.onMsgChange}
+            onClose={() => this.handlers.onCloseThread(m)}
+            live />
+        )
+      } else {
+        listEls.push(
+          <ListItem
+            key={m.key}
+            msg={m}
+            selectiveUpdate
+            {...this.handlers}
+            {...this.props.listItemProps}
+            forceRaw={this.props.forceRaw} />
+        )
+      }
+    })
+
+    return <div className="msg-list">
+      <div className="msg-list-items">
+        { this.state.msgs.length === 0 && this.state.isLoading ? <div style={{fontWeight: 300, textAlign: 'center'}}>Loading...</div> : '' }
+        { isEmpty && (this.props.emptyMsg !== false) ?
+          <div className="empty-msg">
+            { (this.props.emptyMsg || 'No messages.') }
+          </div>
+          :
+          <ResponsiveElement widthStep={250}>
+            <ReactCSSTransitionGroup component="div" transitionName="fade" transitionAppear={true} transitionAppearTimeout={500} transitionEnterTimeout={500} transitionLeaveTimeout={1}>
+              { listEls }
+            </ReactCSSTransitionGroup>
+          </ResponsiveElement>
+        }
+      </div>
+    </div>
+
+  }
+}

--- a/ui/less/main.less
+++ b/ui/less/main.less
@@ -52,6 +52,7 @@
 @import "transitions/slideup.less";
 @import "transitions/fade.less";
 
+@import "views/home.less";
 @import "views/data.less";
 @import "views/channels.less";
 @import "views/msg.less";

--- a/ui/less/views/home.less
+++ b/ui/less/views/home.less
@@ -1,0 +1,5 @@
+#home {
+  .empty-msg {
+    padding: 0;
+  }
+}

--- a/ui/routes.jsx
+++ b/ui/routes.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { Router, Route, IndexRoute } from 'react-router'
 import app from './lib/app'
 import Layout from './layout'
+import Home from './views/home'
 import Inbox from './views/inbox'
 import PublicPosts from './views/public'
 import Digs from './views/digs'
@@ -32,7 +33,7 @@ app.history.listenBefore(beforeNavigation)
 export var routes = (
   <Router history={app.history}>
     <Route path="/" component={Layout}>
-      <IndexRoute component={Inbox} />
+      <IndexRoute component={Home} />
       <Route path="inbox" component={Inbox} />
       <Route path="inbox/:view" component={Inbox} />
       <Route path="activity" component={PublicPosts} />

--- a/ui/views/home.jsx
+++ b/ui/views/home.jsx
@@ -1,0 +1,66 @@
+'use babel'
+import React from 'react'
+import { Link } from 'react-router'
+import LeftNav from '../com/leftnav'
+import RightNav from '../com/rightnav'
+import MsgList from '../com/msg-list'
+import SimpleMsgList from '../com/msg-list/simple'
+import Oneline from '../com/msg-view/oneline'
+import Card from '../com/msg-view/card'
+import Dropdown from '../com/dropdown'
+import app from '../lib/app'
+
+export default class Home extends React.Component {
+  onMarkAllRead() {
+    app.ssb.patchwork.markAllRead('inbox', err => {
+      if (err)
+        app.issue('Failed to mark all read', err)
+    })
+  }
+
+  render() {
+    const cursor = msg => {
+      if (msg)
+        return [msg.ts, false]
+    }
+    const inboxSource = opts => {
+      opts.unread = true
+      return app.ssb.patchwork.createInboxStream(opts)
+    }
+
+    // component for hero (inbox)
+    const Hero = props => {
+      const emptyMsg = false//<div>You have no unread messages. <Link to="/inbox?archived=1">View Archived</Link></div>
+      return <SimpleMsgList threads ListItem={Oneline} source={inboxSource} cursor={cursor} live={{ gt: [Date.now(), null] }} emptyMsg={false} />
+    }
+
+    // component for rightnav
+    const ThisRightNav = props => {
+      const markAllReadItems = [{ label: 'Are you sure? Click here to confirm.', onSelect: this.onMarkAllRead.bind(this) }]
+      return <RightNav>
+        <hr className="labeled" data-label="inbox" />
+        <Dropdown className="btn hint--top-left" data-hint="Mark all messages on this page as 'read'." items={markAllReadItems} right>
+          <i className="fa fa-envelope" /> Mark all read
+        </Dropdown>
+      </RightNav>
+    }
+
+    // render
+    return <div id="home">
+      <MsgList
+        ref="list"
+        threads
+        dateDividers
+        batchLoadAmt={5}
+        composer composerProps={{ isPublic: true }}
+        Hero={Hero}
+        LeftNav={LeftNav} leftNavProps={{ location: this.props.location }}
+        RightNav={ThisRightNav}
+        ListItem={Card} listItemProps={{ listView: true }}
+        live={{ gt: [Date.now(), null] }}
+        emptyMsg="Your feed is empty"
+        source={app.ssb.patchwork.createPublicPostStream}
+        cursor={cursor} />
+    </div>
+  }
+}

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -75,7 +75,7 @@ export default class InboxPosts extends React.Component {
     }
     const emptyMsg = showArchived
       ? <div>Your inbox is empty.</div>
-      : <div> You have no unread messages. <Link to={archivedUrl}>View Archived</Link></div>
+      : <div>You have no unread messages. <Link to={archivedUrl}>View Archived</Link></div>
 
     // render
     return <div id="inbox" key={view+(showArchived?'-all':'-unread')}>


### PR DESCRIPTION
It was bugging me that I had to switch between the inbox and activity feed pages. So I created a new Home page, which puts the unread inbox items at the top of the feed:

![screen shot 2016-03-12 at 7 17 27 pm](https://cloud.githubusercontent.com/assets/1270099/13726308/59e3f304-e887-11e5-9159-9608b0b2ce49.png)

If there are no unread items in the inbox, then this area is empty.

Looking for feedback on this change.
