### PR TITLE
Show archived items in the inbox subfolders

### DIFF
--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -50,7 +50,7 @@ export default class InboxPosts extends React.Component {
 
   render() {
     // setup params based on view, and whether we're looking at archived items
-    const showArchived = this.props.location.query.archived
+    const showArchived = this.props.location.query.archived || !!this.props.params.view
     const hasUnread = this.getUnreadCount() > 0
     const view = this.props.params.view || 'inbox'
     const viewLabel = view


### PR DESCRIPTION
Now only the main inbox view will hide read messages. The other subviews (private, mentions, etc) show all by default