### PR TITLE
Only mark thread-replies unread

### DIFF
--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -240,21 +240,6 @@ export default class MsgList extends React.Component {
     this.loadMore({ amt })
   }
 
-  /*onClickAnything(e) {
-    // if the user clicks the background, close the thread
-    for (var node = e.target; node; node = node.parentNode) {
-      if (!node.classList)
-        return
-      if (node.classList.contains('msg-view') || node.classList.contains('items'))
-        return // abort, it's a click within the messages
-      if (node.classList.contains('msg-list')) {
-        // reached our toplevel, lets close the thread
-        this.setState({ currentOpenMsgKey: null })
-        return
-      }
-    }
-  }*/
-
   processMsg(msg, cb) {
     // fetch thread data if not already present (using `related` as an indicator of that)
     if (this.props.threads && msg.value && !('related' in msg)) {

--- a/ui/com/msg-thread.jsx
+++ b/ui/com/msg-thread.jsx
@@ -197,7 +197,13 @@ export default class Thread extends React.Component {
   onMarkUnread() {
     // mark unread in db
     let thread = this.state.thread
-    let keys = this.state.flattenedMsgs.filter(m => !m._isRead).map(m => m.key) // mark unread the ones that were unread on expand
+    let keys = this.state.flattenedMsgs
+      .filter(m => {
+        if (mlib.relationsTo(thread, m).indexOf('root') === -1)
+          return false // replies only
+        return !m._isRead // mark unread the ones that were unread on expand
+      })
+      .map(m => m.key)
     keys.push(thread.key)
     app.ssb.patchwork.markUnread(keys, err => {
       if (err)


### PR DESCRIPTION
Fixes a bug where mark-unread could accidently affect messages which mention the current thread