### PR TITLE
Enforce CORS restriction on the API WebSocket

### DIFF
--- a/config.js
+++ b/config.js
@@ -5,8 +5,11 @@ module.exports = function (conf) {
     getHostname: function () {
       return conf.host || 'localhost'
     },
+    getPort: function () {
+      return 7777
+    },
     getLocalUrl: function () {
-      return 'http://localhost:7777/'
+      return (oracle.useTLS()?'https':'http')+'://'+oracle.getHostname()+':'+oracle.getPort()
     },
 
     allowRemoteAccess: function () {

--- a/index.js
+++ b/index.js
@@ -54,15 +54,14 @@ var httpStack = require('./http-server')
 var httpServerFn = httpStack.AppStack(sbot, { uiPath: path.join(__dirname, 'ui') }, configOracle)
 var wsServerFn = require('./ws-server')(sbot)
 
-var server = ws.createServer(configOracle.useTLS() ? configOracle.getTLS() : null)
+var serverOpts = configOracle.useTLS() ? configOracle.getTLS() : {}
+serverOpts.verifyClient = require('./ws-server').verifyClient(configOracle)
+var server = ws.createServer(serverOpts)
 server.on('error', fatalError)
 server.on('connection', wsServerFn)
 server.on('request', httpServerFn)
-server.listen(7777)
-if (configOracle.useTLS())
-  console.log('Serving at https://localhost:7777')
-else
-  console.log('Serving at http://localhost:7777')
+server.listen(configOracle.getPort())
+console.log('Serving at', configOracle.getLocalUrl())
 
 // basic error handling
 function fatalError (e) {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "pull-serializer": "^0.3.2",
     "pull-stream": "^2.27.0",
     "pull-stream-to-stream": "~1.3.0",
-    "pull-ws-server": "^1.3.4",
+    "pull-ws-server": "^1.6.2",
     "react": "^0.14.3",
     "react-addons-css-transition-group": "^0.14.3",
     "react-clipboard.js": "^0.1.7",

--- a/ws-server.js
+++ b/ws-server.js
@@ -16,3 +16,10 @@ module.exports = function (sbot, opts) {
 function serialize (stream) {
   return Serializer(stream, JSON, {split: '\n\n'})
 }
+
+module.exports.verifyClient = function (config) {
+  return function (info) {
+    console.log(info.origin)
+    return info.origin === config.getLocalUrl()
+  }
+}


### PR DESCRIPTION
This PR makes it so only pages hosted by Patchwork (localhost:7777) can access the WebSocket.

It relies on the Origin header being set correctly. Programs outside of the browser, which are able to set headers freely, will be able to circumvent this protection.