### PR TITLE
Fix: dont put mentions in the feed inline replies

### DIFF
--- a/ui/com/msg-view/card.jsx
+++ b/ui/com/msg-view/card.jsx
@@ -371,7 +371,10 @@ export default class Card extends React.Component {
 }
 
 function getLastTwoPosts (msg) {
-  var lastTwo = threadlib.flattenThread(msg).slice(-2)
+  var lastTwo = threadlib
+    .flattenThread(msg)
+    .filter(reply => mlib.relationsTo(reply, msg).indexOf('root') >= 0)
+    .slice(-2)
   if (lastTwo[0].key === msg.key)
     return lastTwo.length === 2 ? [lastTwo[1]] : [] // dont let the original be included
   return lastTwo


### PR DESCRIPTION
Mentions were showing up in the inline replies of the feedview. It didnt look right, so this PR removes them.