### PR TITLE
Render missing messages in the inbox

### DIFF
--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -340,10 +340,6 @@ export default class MsgList extends React.Component {
     var lastDate = moment().startOf('day').add(1, 'day')
     var listEls = []
     this.state.msgs.forEach((m, i) => {
-      // missing value?
-      if (!m.value)
-        return // dont render
-
       // render a date divider if this post is from a different day than the last
       const oldLastDate = lastDate
       lastDate = moment(m.ts || m.value.timestamp).endOf('day')

--- a/ui/com/msg-view/oneline.jsx
+++ b/ui/com/msg-view/oneline.jsx
@@ -28,9 +28,20 @@ export default class Oneline extends React.Component {
 
   render() {
     const msg = this.props.msg
-    const lastMsg = !this.props.forceRaw ? threadlib.getLastThreadPost(msg) : false
+    const lastMsg = (!this.props.forceRaw && msg.value) ? threadlib.getLastThreadPost(msg) : false
     let replies = countReplies(msg)
     replies = (replies === 0) ? '' : `(${replies+1})`
+
+    if (!msg.value) {
+      return <div className={'msg-view oneline'+(msg.hasUnread ? ' unread' : '')+(!msg.plaintext ? ' private' : '')} onClick={this.onClick.bind(this)}>
+        <div className="authors">
+          <span className="replies">{replies}</span>
+        </div>
+        <div className="content">
+          <span className="markdown markdown-inline">Missing message</span>
+        </div>
+      </div>
+    }
 
     var labelIcons = []
     if (!msg.plaintext)   labelIcons.push(<i key="lock" className="fa fa-lock" />)


### PR DESCRIPTION
Sometimes you'll get a thread added to your inbox, even though you don't have the root message. (Most common reason: you're mentioned in a reply.)

This update causes that message to at least render.