### PR TITLE
Only show missing msgs in the inbox

### DIFF
--- a/ui/com/msg-list.jsx
+++ b/ui/com/msg-list.jsx
@@ -340,6 +340,9 @@ export default class MsgList extends React.Component {
     var lastDate = moment().startOf('day').add(1, 'day')
     var listEls = []
     this.state.msgs.forEach((m, i) => {
+      if (!m.value && !this.props.showMissing)
+        return // skip missing msgs
+
       // render a date divider if this post is from a different day than the last
       const oldLastDate = lastDate
       lastDate = moment(m.ts || m.value.timestamp).endOf('day')

--- a/ui/com/msg-view/card.jsx
+++ b/ui/com/msg-view/card.jsx
@@ -212,7 +212,7 @@ export default class Card extends React.Component {
 
   render() {
     const msg = this.props.msg
-    if (msg.isNotFound)
+    if (msg.isNotFound || !msg.value)
       return this.renderNotFound(msg)
     if (msg.isLink)
       return this.renderLink(msg)

--- a/ui/views/inbox.jsx
+++ b/ui/views/inbox.jsx
@@ -83,6 +83,7 @@ export default class InboxPosts extends React.Component {
         ref="list"
         threads
         dateDividers
+        showMissing
         composer composerProps={{ isPublic: false }}
         ListItem={Oneline} listItemProps={{ userPic: true }}
         LeftNav={LeftNav} leftNavProps={{ location: this.props.location }}


### PR DESCRIPTION
The main feed doesnt need them to render, just the inbox, so that the unread count and the inbox content match up.