### PR TITLE
Handle notfound msgs

### DIFF
--- a/api/processor.js
+++ b/api/processor.js
@@ -16,7 +16,17 @@ module.exports = function (sbot, db, state, emit) {
       // inbox index:
       // add msgs that mention or address the user
       var inboxRow
-      if (u.findLink(mentions, sbot.id) || u.findLink(recps, sbot.id)) {
+      if (u.findLink(mentions, sbot.id)) {
+        // if a reply, make sure we have the root already
+        if (root)
+          inboxRow = state.inbox.sortedUpdate(msg.received, root.link)
+        if (!inboxRow) {
+          // fallback to inserting the mentioning message, if the root isnt available (or its not a reply)
+          inboxRow = state.inbox.sortedUpsert(msg.received, msg.key)
+        }
+        emit('index-change', { index: 'inbox' })
+        attachChildIsRead(inboxRow, msg.key)
+      } else if (u.findLink(recps, sbot.id)) {
         inboxRow = state.inbox.sortedUpsert(msg.received, root ? root.link : msg.key)
         emit('index-change', { index: 'inbox' })
         attachChildIsRead(inboxRow, msg.key)
@@ -81,9 +91,16 @@ module.exports = function (sbot, db, state, emit) {
 
         // inbox index: add watched channels
         if (index.watched) {
-          var inboxRow = state.inbox.sortedUpsert(ts(msg), root ? root.link : msg.key)
-          emit('index-change', { index: 'inbox' })
-          attachChildIsRead(inboxRow, msg.key)
+          var inboxRow
+          if (root)
+            // only do updates if a reply, we dont want inbox items that dont have a root
+            inboxRow = state.inbox.sortedUpdate(ts(msg), root.link)
+          else
+            inboxRow = state.inbox.sortedInsert(ts(msg), msg.key)
+          if (inboxRow) {
+            emit('index-change', { index: 'inbox' })
+            attachChildIsRead(inboxRow, msg.key)
+          }
         }
       }
     },

--- a/api/processor.js
+++ b/api/processor.js
@@ -16,18 +16,14 @@ module.exports = function (sbot, db, state, emit) {
       // inbox index:
       // add msgs that mention or address the user
       var inboxRow
-      if (u.findLink(mentions, sbot.id)) {
+      if (u.findLink(mentions, sbot.id) || u.findLink(recps, sbot.id)) {
         // if a reply, make sure we have the root already
         if (root)
           inboxRow = state.inbox.sortedUpdate(msg.received, root.link)
         if (!inboxRow) {
-          // fallback to inserting the mentioning message, if the root isnt available (or its not a reply)
+          // fallback to inserting the current message, if the root isnt available (or its not a reply)
           inboxRow = state.inbox.sortedUpsert(msg.received, msg.key)
         }
-        emit('index-change', { index: 'inbox' })
-        attachChildIsRead(inboxRow, msg.key)
-      } else if (u.findLink(recps, sbot.id)) {
-        inboxRow = state.inbox.sortedUpsert(msg.received, root ? root.link : msg.key)
         emit('index-change', { index: 'inbox' })
         attachChildIsRead(inboxRow, msg.key)
       }

--- a/api/util.js
+++ b/api/util.js
@@ -32,7 +32,7 @@ module.exports.index = function (name) {
     return row
   }
 
-  index.sortedUpsert = function (ts, key) {
+  index.sortedUpdate = function (ts, key) {
     var i = index.indexOf(key)
     if (i !== -1) {
       // readd to index at new TS
@@ -47,10 +47,16 @@ module.exports.index = function (name) {
         return row
       } else
         return index.rows[i]
-    } else {
-      // add to index
-      return index.sortedInsert(ts, key)
     }
+  }
+
+  index.sortedUpsert = function (ts, key) {
+    var row = index.sortedUpdate(ts, key)
+    if (!row) {
+      // add to index
+      row = index.sortedInsert(ts, key)
+    }
+    return row
   }
 
   index.remove = function (key, keyname) {

--- a/ui/com/composer/index.jsx
+++ b/ui/com/composer/index.jsx
@@ -52,17 +52,19 @@ class CompositionUnit extends React.Component {
     this.isThreadPublic = null
     this.threadChannel = null
     this.threadRootKey = null
-    if (this.props.thread) {
+    if (this.props.thread && !this.isThreadMissing()) {
+      const thread = this.props.thread
+
       // thread categorization
-      this.isThreadPublic = isThreadPublic(this.props.thread)
-      this.threadChannel = (this.props.thread.value.content.channel || '').trim()
+      this.isThreadPublic = isThreadPublic(thread)
+      this.threadChannel = (thread.value.content.channel || '').trim()
 
       // root link
-      this.threadRootKey = getThreadRoot(this.props.thread)
+      this.threadRootKey = getThreadRoot(thread)
 
       // extract encryption recipients from thread
-      if (Array.isArray(this.props.thread.value.content.recps)) {
-        recps = mlib.links(this.props.thread.value.content.recps)
+      if (thread.value && Array.isArray(thread.value.content.recps)) {
+        recps = mlib.links(thread.value.content.recps)
                     .map(function (recp) { return recp.link })
                     .filter(Boolean)
       }
@@ -83,6 +85,10 @@ class CompositionUnit extends React.Component {
 
   isReply() {
     return !!this.props.thread
+  }
+
+  isThreadMissing() {
+    return this.isReply() && !this.props.thread.value
   }
 
   getDraftId() {
@@ -289,6 +295,9 @@ class CompositionUnit extends React.Component {
   }
 
   renderComposerArea() {
+    if (this.isThreadMissing())
+      return <span/> // dont render
+
     const channel = this.getChannel()
     const vertical = this.props.verticalFilled
     const togglePreviewing = this.togglePreviewing.bind(this)

--- a/ui/com/msg-thread.jsx
+++ b/ui/com/msg-thread.jsx
@@ -310,14 +310,14 @@ export default class Thread extends React.Component {
     }
 
     const thread = this.state.thread
-    const threadRoot = thread && mlib.link(thread.value.content.root, 'msg')
+    const threadRoot = thread && thread.value && mlib.link(thread.value.content.root, 'msg')
     const isViewingReply = !!threadRoot
     const msgs = (this.state.isHidingHistory) ? this.state.collapsedMsgs : this.state.flattenedMsgs
     const canMarkUnread = thread && (thread.isBookmarked || !thread.plaintext)
     const isPublic = (thread && thread.plaintext)
-    const authorName = thread && u.getName(thread.value.author)
-    const channel = thread && thread.value.content.channel
-    const recps = thread && mlib.links(thread.value.content.recps, 'feed')
+    const authorName = thread && thread.value && u.getName(thread.value.author)
+    const channel = thread && thread.value && thread.value.content.channel
+    const recps = thread && thread.value && mlib.links(thread.value.content.recps, 'feed')
 
     return <div className="msg-thread" ref="container">
       { !thread

--- a/ui/com/msg-view/card.jsx
+++ b/ui/com/msg-view/card.jsx
@@ -212,12 +212,12 @@ export default class Card extends React.Component {
 
   render() {
     const msg = this.props.msg
-    if (msg.isNotFound || !msg.value)
-      return this.renderNotFound(msg)
     if (msg.isLink)
       return this.renderLink(msg)
     if (msg.isMention)
       return this.renderMention(msg)
+    if (msg.isNotFound || !msg.value)
+      return this.renderNotFound(msg)
     const upvoters = getVotes(this.props.msg, userId => msg.votes[userId] === 1)
     const downvoters = getVotes(this.props.msg, userId => userIsTrusted(userId) && msg.votes[userId] === -1)
     const isUpvoted = upvoters.indexOf(app.user.id) !== -1


### PR DESCRIPTION
There's been a (fortuitous) situation where, for some reason, Im not receiving a FoaF's feed in a timely fashion. (That's probably a bug!) But, the good news is, it's letting me see what happens when there are a lot of missing messages.

This PR adds some defensive guards against missing messages (sanity checks). I decided it's simplest to disallow replies on a thread that's missing it's root, because the typical logic is to read metadata from the root (channel, recipients, is encrypted?, etc)

I also updated the inbox index so that it doesnt add missing messages:
 - If it's a private message or mention, and the root isnt available, the message that *is* available will go in your inbox. That would be, the reply you just received, or the message that mentioned you.
 - If it's a message in a channel you watch, it wont get indexed at all.