### PR TITLE
Update to scuttlebot@8

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "react-modal": "^0.6.0",
     "react-notification": "^4.2.0",
     "react-router": "1.0.2",
-    "scuttlebot": "~7.6.4",
+    "scuttlebot": "^8.0.0",
     "ssb-config": "^1.2.1",
     "ssb-keys": "^5.0.0",
     "ssb-markdown": "^3.0.0",


### PR DESCRIPTION
Recent changes in [sbot 8](https://github.com/ssbc/scuttlebot/pull/326), where breaking for the network sync page.

This gets it working again with some changes - mainly I have ordered the list by the peer most recently connected to, so the list now shows your best peers at the top, (currently connected, then peers you have successfully connected to, ordered by most recent connection!)

to discuss:
I've disabled the graph view currently, this takes a lot of CPU power to run and doesn't really add much to the experience currently, I propose we remove the graph until we have time to do another iteration. @mixmix 

merging this will mean we can fully roll out sbot8 which gives us long term connection everywhere