### PR TITLE
set default background-color for user input elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 ui/css/main.css
 ui/main.build.js
 browserify-cache.json
+.*.swp

--- a/ui/less/colors.less
+++ b/ui/less/colors.less
@@ -1,0 +1,1 @@
+@color-user-input: white;

--- a/ui/less/colors.less
+++ b/ui/less/colors.less
@@ -1,1 +1,0 @@
-@color-user-input: white;

--- a/ui/less/com/topnav.less
+++ b/ui/less/com/topnav.less
@@ -21,7 +21,7 @@
     }
     .search-palette {
       input {
-        background-color: @color-user-input;
+        background-color: white;
       }
     }
   }

--- a/ui/less/com/topnav.less
+++ b/ui/less/com/topnav.less
@@ -19,6 +19,11 @@
         top: 1px;
       }
     }
+    .search-palette {
+      input {
+        background-color: @color-user-input;
+      }
+    }
   }
   .topnav-composer {
     margin-top: 10px;

--- a/ui/less/main.less
+++ b/ui/less/main.less
@@ -2,8 +2,6 @@ body {
   background: #eee;
 }
 
-@import "colors.less";
-
 @import "node_modules/patchkit-base-styles/all.less";
 @import "elevations.less"; // TODO remove
 @import "layout.less";

--- a/ui/less/main.less
+++ b/ui/less/main.less
@@ -2,6 +2,8 @@ body {
   background: #eee;
 }
 
+@import "colors.less";
+
 @import "node_modules/patchkit-base-styles/all.less";
 @import "elevations.less"; // TODO remove
 @import "layout.less";

--- a/ui/less/views/composer.less
+++ b/ui/less/views/composer.less
@@ -6,6 +6,6 @@
 
 .composer-content {
   textarea {
-    background-color: @color-user-input;
+    background-color: white;
   }
 }

--- a/ui/less/views/composer.less
+++ b/ui/less/views/composer.less
@@ -3,3 +3,9 @@
     margin: 5px;
   }
 }
+
+.composer-content {
+  textarea {
+    background-color: @color-user-input;
+  }
+}


### PR DESCRIPTION
I'll start by saying I'm totally open to doing everything I did in a different way, but this PR has some minor improvements (for those running on a somewhat sketchy platform).

I read through some of the less files, and set these new values where I thought they made sense.

My problem was that gnome's dark theme gives firefox input and textareas a black background, which made user input fields practically unreadable in poor lighting.

I found two seemingly appropriate files for adding style rules for these elements, and set their values to use `@color-user-input`. This value is defined in a new file I created (colors.less).

My thought was that if we start to put colors into one file, it will be easier in the future for people to reskin their client by tweaking these values. I used 'white' for a background.

Thoughts?