### PR TITLE
Use ssb-notifier for desktop notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var sbot = require('scuttlebot')
   .use(require('scuttlebot/plugins/logging'))
   .use(require('scuttlebot/plugins/private'))
   .use(require('scuttlebot/plugins/local'))
+  .use(require('ssb-notifier'))
   .use(require('./api'))
   (config)
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "ssb-markdown": "^3.0.0",
     "ssb-msg-schemas": "~6.1.0",
     "ssb-msgs": "~5.2.0",
+    "ssb-notifier": "^2.0.0",
     "ssb-ref": "~2.3.0",
     "stack": "^0.1.0",
     "stream-to-pull-stream": "^1.6.1",


### PR DESCRIPTION
Adds native desktop notifications via ssb-notifier (which uses freedesktop-notifications and node-notifier).

Ref #114, #373, #243