### PR TITLE
Fix local peer detection

### DIFF
--- a/ui/views/sync.jsx
+++ b/ui/views/sync.jsx
@@ -29,9 +29,7 @@ function peerSorter (a, b) {
 }
 
 function isLAN (peer) {
-  // TODO this looks like a typo? 
-  //return peer.host == ip.isLoopback(peer.host) || ip.isPrivate(peer.host)
-  return ip.isPrivate(peer.host) || ip.isLoopback(peer.host)
+  return peer.source === 'local'
 }
 
 function isNotLAN (peer) {


### PR DESCRIPTION
Decide if a peer is local based on whether it was found locally (vs. from a pub announcement) rather than based on whether its IP address is considered local. This fixes the issue of peers with cjdns IP addresses appearing as local as discussed in `%WUeEF57h1/YmMvNKsvv15sV/N9mKtOFoHJUbE0VKoKE=.sha256` and `%+kql+KJMI1m4KKM0ejZJSmQoA7JKEMz212TyAdIEhWI=.sha256`