### PR TITLE
Remove link to electron instructions as no need

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ Patchwork embeds the [Scuttlebot networked database](https://github.com/ssbc/scu
 
 ## [Install Instructions](./docs/install.md)
 
-## [Electron Version](https://github.com/ssbc/patchwork-electron)
-
 ## Docs
 
 - [Help / FAQ](./docs/help-faq.md)


### PR DESCRIPTION
Install instructions now ref electron release. So need for confusing duplicated instructions (previously read like perform install instructions, then get electron version)