### PR TITLE
bump babel to update minimatch to 3.0.2 (regexp ddos attack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "nodemon": "^1.8.1",
     "osenv": "~0.1.0",
     "rimraf": "~2.2.8",
-    "tape": "~3.0.0",
+    "tape": "^4.6.0",
     "watchify": "^3.7.0"
   },
   "dependencies": {
-    "babel": "^5.8.23",
+    "babel": "^6.5.2",
     "blob-to-buffer": "^1.2.3",
     "classnames": "^2.2.3",
     "cross-env": "^1.0.8",


### PR DESCRIPTION
![screenshot from 2016-08-07 12 52 41](https://cloud.githubusercontent.com/assets/308049/17462036/5a559874-5c9f-11e6-8c68-9af5e51a940e.png)
