### PR TITLE
fix default width on electron and stop navbars from overlapping conent

### DIFF
--- a/electron/windows.js
+++ b/electron/windows.js
@@ -35,8 +35,8 @@ function _unref () {
 
 function create (opts) {
   opts = extend({
-    width: 1024,
-    height: 768,
+    width: 1100,
+    height: 800,
     preload: require('path').join(__dirname, '../ui/preload.js'),
     webPreferences: webPreferences
   }, opts)

--- a/ui/less/com/sidenavs.less
+++ b/ui/less/com/sidenavs.less
@@ -74,7 +74,7 @@
         }
       }
     }
-    i { 
+    i {
       width: 15px;
       text-align: center;
     }
@@ -119,7 +119,7 @@
     overflow-x: hidden;
   }
 }
-@media(min-width: 1000px) {
+@media(min-width: 1080px) {
   .leftnav {
     position: absolute;
     z-index: 1;
@@ -172,7 +172,7 @@
     }
   }
 }
-@media(max-width: 1000px) {
+@media(max-width: 1079px) {
   .rightnav {
     display: none;
   }


### PR DESCRIPTION
Currently when I open patchwork I see:

<img width="1007" alt="screen shot 2016-09-29 at 3 33 09 pm" src="https://cloud.githubusercontent.com/assets/66834/18939726/e1e2afb4-865e-11e6-88cd-7cf964815f48.png">

Which is a real shame 😞 because if I manually resize the window, it looks beautiful! 🌈 

**This pull request does two things:**
- Increase the default electron window size to **1100px** wide (this is still fine on smaller screens because the platform shrinks it down to fit)
- Increase the width for the sidebars to shrink from 1000 to 1080px (no more ugly overlapping content)