### PR TITLE
electron: allow reopen main window when backgrounding on macOS

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -6,10 +6,20 @@ var setupMainMenu = require('./menu')
 module.exports = function (configOracle) {
   // Quit when all windows are closed.
   app.on('window-all-closed', function() {
-    // On OS X it is common for applications and their menu bar
+    // On macOS it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q
     if (process.platform != 'darwin') {
       app.quit()
+    }
+  })
+
+  app.on('activate', function(ev, hasVisibleWindows) {
+    // Only called on macOS. When main window is closed, app goes into
+    // background mode. Clicking its dock icon reopens main window.
+    if (!hasVisibleWindows) {
+      var mainWindow = windows.create()
+      mainWindow.loadURL(configOracle.getLocalUrl())
+      setupMainMenu(configOracle)
     }
   })
 
@@ -17,5 +27,5 @@ module.exports = function (configOracle) {
     var mainWindow = windows.create()
     mainWindow.loadURL(configOracle.getLocalUrl())
     setupMainMenu(configOracle)
-  });
+  })
 }


### PR DESCRIPTION
On **macOS**, it is semi-normal for apps to go into background mode when their main window is closed. This is the way patchwork works too. Currently when you close the main window, patchwork keeps running in the background. This is great! (and was responsible for the random sync at Camp JS a few months back over stormy beach 3G)

But unfortunately **there is currently no way to reopen the main window without fully quitting patchwork and reopening**. If you reclick its icon, NOTHING HAPPENS. Which makes for a rather shoddy experience and looks like it has crashed if you don't know what's going on.

**This PR solves this problem by making it so that clicking the dock icon will reopen the main window.**

With this fix, backgrounding becomes a really nice feature specific to the macOS version.✨ ... i'm sure it'll keep them apple UX fanboys happy 😉 