### PR TITLE
fix display of "Digs on your posts" menu item

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -231,7 +231,7 @@ module.exports = function (configOracle) {
         },
 
         {
-          label: 'NoticesMenuItem',
+          label: t('NoticesMenuItem'),
           accelerator: 'CmdOrCtrl+Shift+D',
           click: function (item, win) {
             win.webContents.executeJavaScript('app.history.pushState(null, "notices")')


### PR DESCRIPTION
The "Digs on your posts" menu item is currently showing as "NoticesMenuItem" due to a typo. This PR fixes it so that it uses the localisation as intended!