### PR TITLE
update scuttlebot to v9

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,11 +40,8 @@ var createSbot = require('scuttlebot')
   .use(require('scuttlebot/plugins/logging'))
   .use(require('scuttlebot/plugins/private'))
   .use(require('scuttlebot/plugins/local'))
-  .use(require('scuttlebot/plugins/plugins'))
   .use(require('ssb-notifier'))
   .use(require('./api'))
-
-require('scuttlebot/plugins/plugins').loadUserPlugins(createSbot, config)
 
 var sbot = createSbot(config)
 
@@ -90,3 +87,4 @@ if (process.versions['electron']) {
 function logLicense () {
   console.log(t('LicenseConsole', {years: '2015-2016'}) + '\n')
 }
+

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-router": "1.0.2",
     "scuttlebot": "^9.0.0",
     "shx": "^0.1.2",
-    "ssb-blobs": "0.0.5",
+    "ssb-blobs": "^0.1.6",
     "ssb-config": "^2.0.0",
     "ssb-keys": "^6.1.1",
     "ssb-markdown": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "react-modal": "^0.6.0",
     "react-notification": "^4.2.0",
     "react-router": "1.0.2",
-    "scuttlebot": "^8.6.1",
+    "scuttlebot": "^9.0.0",
     "shx": "^0.1.2",
     "ssb-blobs": "0.0.5",
     "ssb-config": "^2.0.0",


### PR DESCRIPTION
this removes the plugin plugin - it was mostly awkward. I think it would be easier to use by creating a custom distribution that wraps sbot, like the way patchwork does it.

Also, it incorporates some performance improvements on replication, shifts to using multiserver internally,
and most interestingly now supports pubs running on tor. (thanks to @arj03)