### PR TITLE
rename from mmckegg/patchwork-next to ssbc/patchwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
-patchwork-next
-===
+# patchwork
 
-A work-in-progress remake of [Patchwork](https://github.com/ssbc/patchwork) using [patchcore](https://github.com/ssbc/patchcore) and UX/ideas from [ferment](https://github.com/mmckegg/ferment).
+A remake of [Patchwork Classic](https://github.com/ssbc/patchwork-classic) using [patchcore](https://github.com/ssbc/patchcore) and UX/ideas from [ferment](https://github.com/mmckegg/ferment).
 
 The goal is to make a standalone, easy to install, "social" view into the ssb world.
 
-![](screenshot.jpg)
+![Patchwork screenshot](screenshot.jpg)
 
 ## Install and run
 
 ```shell
-$ git clone https://github.com/mmckegg/patchwork-next
-$ cd patchwork-next
+$ git clone https://github.com/ssbc/patchwork
+$ cd patchwork
 $ npm install
 $ npm start
 ```

--- a/main-window.js
+++ b/main-window.js
@@ -75,7 +75,7 @@ module.exports = function (config) {
     ]),
     when(latestUpdate,
       h('div.info', [
-        h('a.message -update', { href: 'https://github.com/mmckegg/patchwork-next/releases' }, [
+        h('a.message -update', { href: 'https://github.com/ssbc/patchwork/releases' }, [
           h('strong', ['Patchwork ', latestUpdate, ' has been released.']), ' Click here for more info!'
         ])
       ])

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "patchwork-next",
+  "name": "ssb-patchwork",
   "productName": "Patchwork",
   "version": "3.2.0",
   "description": "A decentralized messaging and sharing app built on top of Secure Scuttlebutt (SSB).",


### PR DESCRIPTION
Patchwork v3 is live! <https://github.com/ssbc/patchwork> :tada:

Patchwork v2 (Classic) has been moved to <https://github.com/ssbc/patchwork-classic>

this pull request is to fix any naming bits.