### PR TITLE
add context menu item to copy message text

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -96,6 +96,14 @@ module.exports = new ContextMenuListener((info) => {
           clipboard.writeText(element.msg.key)
         }
       }))
+      if (element.msg.value.content.text) {
+        menu.append(new MenuItem({
+          label: 'Copy Message Text',
+          click: function () {
+            clipboard.writeText(element.msg.value.content.text)
+          }
+        }))
+      }
     }
     menu.popup(remote.getCurrentWindow())
   }).catch((err) => {


### PR DESCRIPTION
the use case is to copy the raw text of a message. if you try to highlight and copy the text from the interface, you will miss all the markdown formatting.

my usual tactic is to use `sbot get {messageId}`, but i wanted to copy a private message's text which is encrypted when displayed with `sbot get`.