### PR TITLE
adds ssb-notifier to enable desktop notification

### DIFF
--- a/server-process.js
+++ b/server-process.js
@@ -15,6 +15,7 @@ var createSbot = require('scuttlebot')
   .use(require('scuttlebot/plugins/logging'))
   .use(require('./lib/private-with-index'))
   .use(require('./lib/query-with-progress'))
+  .use(require('ssb-notifier'))
 //.use(require('ssb-fulltext')) // disabled for now
 
 module.exports = function (ssbConfig) {


### PR DESCRIPTION
adds `.use(require('ssb-notifier'))` to server-process.js to enable desktop notifications