### PR TITLE
bump level - uses leveldown with prebuilt binaries for electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "has-network": "0.0.0",
     "insert-css": "~1.0.0",
     "is-visible": "^2.1.1",
-    "level": "~1.4.0",
+    "level": "^1.6.0",
     "level-memview": "0.0.0",
     "map-filter-reduce": "~3.0.3",
     "micro-css": "^2.0.0",


### PR DESCRIPTION
```
> leveldown@1.6.0 install /home/lms/src/ssbc/patchwork/node_modules/leveldown               
> prebuild-install || node-gyp rebuild                                                      
                                                                                            
prebuild-install info begin Prebuild-install version 2.1.1                                  
prebuild-install info looking for local prebuild @ prebuilds/leveldown-v1.6.0-electron-v50-l
inux-x64.tar.gz                                                                             
prebuild-install info looking for cached prebuild @ /home/lms/.npm/_prebuilds/https-github.c
om-level-leveldown-releases-download-v1.6.0-leveldown-v1.6.0-electron-v50-linux-x64.tar.gz  
prebuild-install info found cached prebuild                                                 
prebuild-install info unpacking @ /home/lms/.npm/_prebuilds/https-github.com-level-leveldown
-releases-download-v1.6.0-leveldown-v1.6.0-electron-v50-linux-x64.tar.gz                    
prebuild-install info unpack resolved to /home/lms/src/ssbc/patchwork/node_modules/leveldown
/build/Release/leveldown.node                                                               
prebuild-install info install Prebuild successfully installed!                              
npm WARN prefer global ssb-marked@0.7.1 should be installed with -g                         
npm WARN prefer global node-gyp@3.6.0 should be installed with -g                           
npm WARN prefer global node-ninja@1.0.2 should be installed with -g                         
```

Cuts down install time with 15 seconds, not a lot but always a start :) I think there's a lot of room for improvement here, especially getting prebuilts made for electron for sodium-prebuilt cc @mafintosh