### PR TITLE
add missing debian deps for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ npm start
 On linux you'll need some more dependencies for the spell-checker. On debian:
 
 ```shell
-sudo apt-get install libxext-dev libxtst-dev libxkbfile-dev
+sudo apt-get install libxext-dev libxtst-dev libxkbfile-dev g++ m4 automake libtool
 ```
 
 ## Docs


### PR DESCRIPTION
stumbled upon those missing deps when getting from source on x86.