### PR TITLE
Use valid SPDX license, fixes npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "rebuild": "npm rebuild --runtime=electron --target=1.4.3 --abi=50 --disturl=https://atom.io/download/atom-shell"
   },
   "author": "Secure Scuttlebutt Consortium",
-  "license": "GPL",
+  "license": "GPL-3.0",
   "dependencies": {
     "atomic-file": "^0.1.0",
     "bulk-require": "^1.0.0",


### PR DESCRIPTION
Same license as patchbay:
https://github.com/ssbc/patchbay/blob/e1ed6f570e6bc64d0e62569002f67eace00218bb/package.json#L29