### PR TITLE
[wip] New rollup and feed ordering

### DIFF
--- a/lib/ssb-rollup.js
+++ b/lib/ssb-rollup.js
@@ -1,0 +1,208 @@
+var SortedArray = require('sorted-array-functions')
+var ref = require('ssb-ref')
+
+module.exports = rollupMessages
+
+function rollupMessages (messages, opts, cb) {
+  var messageFilter = opts && opts.messageFilter || function (messages, cb) {
+    cb(null, messages)
+  }
+
+  var compare = opts && opts.compare || function (a, b) {
+    return messages.indexOf(last(a.bumps)) - messages.indexOf(last(b.bumps))
+  }
+
+  // Group by thread (for posts) and topic (for follows, subscribes)
+  var grouped = groupByType(messages)
+
+  // preserve original message ordering for thread ordering
+  grouped.bumps = getThreadBumps(grouped, (a, b) => {
+    return messages.indexOf(a) - messages.indexOf(b) || 0
+  })
+
+  // filter messages using provided function (remove non-friends, etc)
+  messageFilter(grouped, function (err, grouped) {
+    if (err) return cb(err)
+
+    // sort groups by recent actions
+    var result = []
+
+    var rootIds = new Set(Object.keys(grouped.roots).concat(Object.keys(grouped.replies)))
+
+    rootIds.forEach(rootId => {
+      SortedArray.add(result, {
+        type: 'thread',
+        rootId,
+        root: grouped.roots[rootId],
+        replies: grouped.replies[rootId] || [], //
+        likes: grouped.likes[rootId] || [],
+        bumps: grouped.bumps[rootId] || []
+      }, compare)
+    })
+
+    // For follows and subscribes, figure out optimised grouping (friends,
+    // multiple channel subscriptions, users) and insert ordered
+    insertContacts(result, grouped.contacts, compare)
+    // insertChannels(grouped, result)
+
+    cb(null, result)
+  })
+}
+
+function getThreadBumps (grouped, compare) {
+  var result = {}
+  Object.keys(grouped.roots).forEach(key => {
+    result[key] = [grouped.roots[key]]
+  })
+
+  Object.keys(grouped.replies).forEach(key => {
+    var collection = result[key] = result[key] || []
+    addThreadBumps(collection, grouped.replies[key], compare)
+  })
+
+  Object.keys(grouped.likes).forEach(key => {
+    var collection = result[key] = result[key] || []
+    addThreadBumps(collection, grouped.likes[key], compare)
+  })
+
+  return result
+}
+
+function addThreadBumps (result, msgs, compare) {
+  msgs.forEach(msg => {
+    SortedArray.add(result, msg, compare)
+  })
+}
+
+function insertContacts (result, contacts, compare) {
+  var areFriends = new Set()
+  var follows = []
+  var friendCount = {}
+  var profileWasFollowedCount = {}
+  var profileDidFollowCount = {}
+
+  // count the different relationship types
+  Object.keys(contacts).forEach(key => {
+    var msg = contacts[key][0]
+    if (!msg || msg.value.content.following !== true) return
+
+    follows.push(msg)
+
+    var profileId = msg.value.author
+    var targetId = msg.value.content.contact
+    var reverse = contacts[`${targetId}:${profileId}`]
+    var followedBack = reverse && reverse[0] && reverse[0].value.content.following
+    if (followedBack) {
+      friendCount[profileId] = (friendCount[profileId] || 0) + 1
+      friendCount[targetId] = (friendCount[targetId] || 0) + 1
+      areFriends.add(friendshipKey(profileId, targetId))
+    } else {
+      profileDidFollowCount[profileId] = (profileDidFollowCount[profileId] || 0) + 1
+      profileWasFollowedCount[targetId] = (profileWasFollowedCount[targetId] || 0) + 1
+    }
+  })
+
+  var friends = {}
+  var followTargets = {}
+  var followSources = {}
+
+  // sort into groups of follow types
+  follows.forEach(msg => {
+    var profileId = msg.value.author
+    var targetId = msg.value.content.contact
+    if (areFriends.has(friendshipKey(profileId, targetId))) {
+      var id = friendCount[profileId] > friendCount[targetId] ? profileId : targetId
+      ;(friends[id] = friends[id] || []).push(msg)
+    } else if (profileDidFollowCount[profileId] > profileWasFollowedCount[targetId]) {
+      ;(followSources[profileId] = followSources[profileId] || []).push(msg)
+    } else {
+      ;(followTargets[targetId] = followTargets[targetId] || []).push(msg)
+    }
+  })
+
+  // add different types of follows to feed
+  Object.keys(friends).forEach(id => {
+    SortedArray.add(result, {
+      type: 'friends',
+      id,
+      contacts: new Set(friends[id].map(msg => msg.value.author).filter(x => x !== id)),
+      bumps: friends[id]
+    }, compare)
+  })
+
+  Object.keys(followTargets).forEach(id => {
+    SortedArray.add(result, {
+      type: 'follow-target',
+      id,
+      contacts: new Set(followTargets[id].map(msg => msg.value.author)),
+      bumps: followTargets[id]
+    }, compare)
+  })
+
+  Object.keys(followSources).forEach(id => {
+    SortedArray.add(result, {
+      type: 'follow-source',
+      id,
+      contacts: new Set(followSources[id].map(msg => msg.value.content.contact)),
+      bumps: followSources[id]
+    }, compare)
+  })
+}
+
+function length (array) {
+  return array && array.length || 0
+}
+
+function friendsFromKey (key) {
+  return key.split(':')
+}
+
+function friendshipKey (a, b) {
+  return [a, b].sort().join(':')
+}
+
+function groupByType (messages) {
+  return messages.reduce((result, msg) => {
+    var c = msg.value.content
+    if (ref.isMsg(c.root)) { // a reply
+      var collection = result.replies[c.root] = result.replies[c.root] || []
+      collection.push(msg)
+    } else if (c.type === 'vote') { // a like
+      if (c.vote && ref.isMsg(c.vote.link)) {
+        var collection = result.likes[c.vote.link] = result.likes[c.vote.link] || []
+        collection.push(msg)
+      }
+    } else if (c.type === 'post') { // root post
+      result.roots[msg.key] = msg
+    } else if (c.type === 'about' && ref.isFeed(c.about)) { // about profile
+      result.roots[msg.key] = msg
+    } else if (c.type === 'channel') {
+      var channel = c.channel
+      var subscriber = msg.value.author
+      if (typeof channel === 'string' && channel.length && channel.length < 30) {
+        var collection = result.channels[subscriber] = result.channels[subscriber] || []
+        collection.push(msg)
+      }
+    } else if (c.type === 'contact') {
+      var targetId = c.contact
+      if (ref.isFeed(targetId)) {
+        var key = `${msg.value.author}:${targetId}`
+        var collection = result.contacts[key] = result.contacts[key] || []
+        collection.push(msg)
+      }
+    }
+    return result
+  }, {
+    roots: {},
+    replies: {},
+    likes: {},
+    channels: {},
+    contacts: {}
+  })
+}
+
+function last (array) {
+  if (Array.isArray(array)) {
+    return array[array.length - 1]
+  }
+}

--- a/modules/feed/html/rollup.js
+++ b/modules/feed/html/rollup.js
@@ -3,13 +3,16 @@ var when = require('mutant/when')
 var computed = require('mutant/computed')
 var h = require('mutant/h')
 var MutantArray = require('mutant/array')
-var Abortable = require('pull-abortable')
 var map = require('mutant/map')
 var pull = require('pull-stream')
 var nest = require('depnest')
 
 var onceTrue = require('mutant/once-true')
 var Scroller = require('pull-scroll')
+
+var pullNext = require('pull-next')
+var pullDefer = require('pull-defer')
+var rollupMessages = require('../../../lib/ssb-rollup')
 
 exports.needs = nest({
   'message.html': {
@@ -37,253 +40,180 @@ exports.create = function (api) {
   return nest({
     'feed.html': { rollup }
   })
-  function rollup (getStream, opts) {
+  function rollup (getStream, {
+    // opts:
+    prepend,
+    messageFilter,
+    compare,
+    windowSize = 2000,
+    compareMessages
+  }) {
     var sync = Value(false)
-    var updates = Value(0)
-
-    var filter = opts && opts.filter
-    var bumpFilter = opts && opts.bumpFilter
-    var windowSize = opts && opts.windowSize
-    var waitFor = opts && opts.waitFor || true
-
-    var newSinceRefresh = new Set()
-    var newInSession = new Set()
-    var prioritized = {}
-
-    var updateLoader = h('a Notifier -loader', {
-      href: '#',
-      'ev-click': refresh
-    }, [
-      'Show ',
-      h('strong', [updates]), ' ',
-      when(computed(updates, a => a === 1), 'update', 'updates')
-    ])
-
-    var content = Value()
+    var content = h('section.content', {
+      //hidden: computed(sync, s => !s)
+    })
 
     var container = h('Scroller', {
       style: { overflow: 'auto' }
     }, [
       h('div.wrapper', [
-        h('section.prepend', opts.prepend),
+        h('section.prepend', prepend),
         when(sync, null, h('Loading -large')),
         content
       ])
     ])
 
-    onceTrue(waitFor, () => {
-      refresh()
-      pull(
-        getStream({old: false}),
-        pull.drain((item) => {
-          var type = item && item.value && item.value.content.type
+    var last = null
+    var done = false
 
-          // prioritize new messages on next refresh
-          newInSession.add(item.key)
-          newSinceRefresh.add(item.key)
-
-          // ignore message handled by another app
-          if (api.app.sync.externalHandler(item)) return
-
-          if (type && type !== 'vote' && typeof item.value.content === 'object' && item.value.timestamp > twoDaysAgo()) {
-            if (item.value && item.value.author === api.keys.sync.id() && !updates()) {
-              return refresh()
-            }
-            if (filter) {
-              if (item.value.content.type === 'post') {
-                var update = (item.value.content.root) ? {
-                  type: 'message',
-                  messageId: item.value.content.root,
-                  channel: item.value.content.channel
-                } : {
-                  type: 'message',
-                  author: item.value.author,
-                  channel: item.value.content.channel,
-                  messageId: item.key
+    // run rollup of messages in batches of `windowSize || 2000`
+    pull(
+      pullNext(function () {
+        if (!done) {
+          var next = {reverse: true, limit: windowSize, live: false}
+          if (last) next.lt = last.timestamp || last.value.sequence
+          var deferred = pullDefer.source()
+          pull(
+            getStream(next),
+            pull.collect((err, msgs) => {
+              if (err) throw err
+              if (!msgs.length) {
+                done = true
+                deferred.resolve(pull.values([]))
+                sync.set(true)
+              } else {
+                last = msgs[msgs.length - 1]
+                if (typeof compareMessages === 'function') {
+                  msgs.sort(compareMessages)
                 }
-
-                ensureMessageAndAuthor(update, (err, update) => {
-                  if (!err) {
-                    if (filter(update)) {
-                      updates.set(updates() + 1)
-                    }
-                  }
+                rollupMessages(msgs, {messageFilter, compare, windowSize}, (err, result) => {
+                  if (err) throw err
+                  deferred.resolve(
+                    pull.values(result)
+                  )
+                  sync.set(true)
                 })
               }
-            } else {
-              updates.set(updates() + 1)
-            }
-          }
-        })
-      )
-    })
+            })
+          )
+          return deferred
+        }
+      }),
+      Scroller(container, content, renderItem, false, false)
+    )
 
-    var abortLastFeed = null
-
-    var result = MutantArray([
-      when(updates, updateLoader),
-      container
-    ])
-
-    result.reload = refresh
-    result.pendingUpdates = updates
-
-    return result
+    return container
 
     // scoped
 
-    function refresh () {
-      if (abortLastFeed) {
-        abortLastFeed()
-      }
-      updates.set(0)
-      sync.set(false)
-
-      content.set(
-        h('section.content', {
-          hidden: computed(sync, s => !s)
-        })
-      )
-
-      var abortable = Abortable()
-      abortLastFeed = abortable.abort
-
-      prioritized = {}
-      newSinceRefresh.forEach(x => {
-        prioritized[x] = 2
-      })
-
-      pull(
-        api.feed.pull.summary(getStream, {windowSize, bumpFilter, prioritized}, () => {
-          sync.set(true)
-        }),
-        pull.asyncMap(ensureMessageAndAuthor),
-        pull.filter((item) => {
-          // ignore messages that are handled by other apps
-          if (item.rootMessage && api.app.sync.externalHandler(item.rootMessage)) return
-          if (filter) {
-            return filter(item)
-          } else {
-            return true
-          }
-        }),
-        abortable,
-        Scroller(container, content(), renderItem, false, false)
-      )
-
-      // clear high prioritized items
-      newSinceRefresh.clear()
-    }
-
-    function renderItem (item) {
+    function renderItem (item, opts) {
       var classList = []
-      if (item.priority >= 2) {
-        classList.push('-new')
-      }
+      var partial = opts && opts.partial
+      // if (item.priority >= 2) {
+      //   classList.push('-new')
+      // }
 
-      if (item.type === 'message') {
+      if (item.type === 'thread') {
+        var event = getEvent(item)
+        var repliesFrom = getReplyAuthors(item)
+        var likesFrom = getLikeAuthors(item)
+
         var meta = null
-        var previousId = item.messageId
-        var replies = item.replies.slice(-4).map((msg) => {
+        var previousId = item.rootId
+
+        var replies = item.replies.sort((a, b) => {
+          return a.value.timestamp - b.value.timestamp
+        }).slice(-4).map((msg) => {
           var result = api.message.html.render(msg, {
             inContext: true,
             inSummary: true,
             previousId,
-            priority: prioritized[msg.key]
+            //priority: prioritized[msg.key]
           })
           previousId = msg.key
           return result
         })
-        var renderedMessage = item.message ? api.message.html.render(item.message, {inContext: true}) : null
+
+        var renderedMessage = item.root ? api.message.html.render(item.root, {inContext: true}) : null
         if (renderedMessage) {
-          if (item.lastUpdateType === 'reply' && item.repliesFrom.size) {
+          if (event === 'reply') {
             meta = h('div.meta', {
-              title: names(item.repliesFrom)
+              title: names(repliesFrom)
             }, [
-              many(item.repliesFrom, api.profile.html.person), ' replied'
+              many(repliesFrom, api.profile.html.person), ' replied'
             ])
-          } else if (item.lastUpdateType === 'like' && item.likes.size) {
+          } else if (event === 'like') {
             meta = h('div.meta', {
-              title: names(item.likes)
+              title: names(likesFrom)
             }, [
-              many(item.likes, api.profile.html.person), ' liked this message'
+              many(likesFrom, api.profile.html.person), ' liked this message'
             ])
           }
 
-          return h('FeedEvent', [
+          if (item.rootId === '%s4r+WJ30j0X7C6u6geyb7jWjV5ScIli3C8Wrt0K0vjs=.sha256') {
+            console.log(renderedMessage)
+          }
+
+          return h('FeedEvent -post', {
+            attributes: {
+              'data-root-id': item.rootId
+            }
+          }, [
             meta,
             renderedMessage,
             when(replies.length, [
-              when(item.replies.length > replies.length || opts.partial,
-                h('a.full', {href: item.messageId}, ['View full thread'])
+              when(item.replies.length > replies.length || partial,
+                h('a.full', {href: item.rootId}, ['View full thread'])
               ),
               h('div.replies', replies)
             ])
           ])
         } else {
-          // when there is no root message in this window,
-          // try and show reply message, only show like message if we have nothing else to give
-          if (item.repliesFrom.size) {
-            meta = h('div.meta', {
-              title: names(item.repliesFrom)
-            }, [
-              many(item.repliesFrom, api.profile.html.person), ' replied to ', api.message.html.link(item.messageId)
-            ])
-          } else if (item.lastUpdateType === 'like' && item.likes.size) {
-            meta = h('div.meta', {
-              title: names(item.likes)
-            }, [
-              many(item.likes, api.profile.html.person), ' liked ', api.message.html.link(item.messageId)
-            ])
-          }
-
-          // only show this event if it has a meta description
-          if (meta) {
-            return h('FeedEvent', [
-              meta, h('div.replies', replies)
+          // only show this event if it has replies
+          if (repliesFrom.size) {
+            return h('FeedEvent -replies', [
+              h('div.meta', {
+                title: names(repliesFrom)
+              }, [
+                many(repliesFrom, api.profile.html.person), ' replied to ', api.message.html.link(item.rootId)
+              ]),
+              h('div.replies', replies)
             ])
           }
         }
-      } else if (item.type === 'follow') {
-        return h('FeedEvent -follow', {classList}, [
-          h('div.meta', {
-            title: names(item.contacts)
-          }, [
-            api.profile.html.person(item.id), ' followed ', many(item.contacts, api.profile.html.person)
+      } else if (item.type === 'friends') {
+        return h('FeedEvent -friends', {classList}, [
+          h('div.meta', [
+            api.profile.html.person(item.id),
+            ' is now friends with ',
+            h('span', { title: names(item.contacts) }, [
+              many(item.contacts, api.profile.html.person)
+            ])
           ])
         ])
-      } else if (item.type === 'subscribe') {
-        return h('FeedEvent -subscribe', {classList}, [
-          h('div.meta', {
-            title: names(item.subscribers)
-          }, [
-            many(item.subscribers, api.profile.html.person),
-            ' subscribed to ',
-            h('a', {href: `#${item.channel}`}, `#${item.channel}`)
+      } else if (item.type === 'follow-source') {
+        return h('FeedEvent -follow', {classList}, [
+          h('div.meta', [
+            api.profile.html.person(item.id),
+            ' followed ',
+            h('span', { title: names(item.contacts) }, [
+              many(item.contacts, api.profile.html.person)
+            ])
+          ])
+        ])
+      } else if (item.type === 'follow-target') {
+        return h('FeedEvent -follow', {classList}, [
+          h('div.meta', [
+            h('span', { title: names(item.contacts) }, [
+              many(item.contacts, api.profile.html.person)
+            ]),
+            ' followed ',
+            api.profile.html.person(item.id)
           ])
         ])
       }
 
       return h('div')
-    }
-  }
-
-  function ensureMessageAndAuthor (item, cb) {
-    if (item.type === 'message' && !item.message) {
-      if (item.message) {
-        item.rootMessage = item.message
-        cb(null, item)
-      } else {
-        api.sbot.async.get(item.messageId, (_, value) => {
-          if (value) {
-            item.author = value.author
-            item.rootMessage = {key: item.messageId, value}
-          }
-          cb(null, item)
-        })
-      }
-    } else {
-      cb(null, item)
     }
   }
 
@@ -293,13 +223,9 @@ exports.create = function (api) {
   }
 }
 
-function twoDaysAgo () {
-  return Date.now() - (2 * 24 * 60 * 60 * 1000)
-}
-
 function many (ids, fn) {
   ids = Array.from(ids)
-  var featuredIds = ids.slice(-4).reverse()
+  var featuredIds = ids.slice(0, 4)
 
   if (ids.length) {
     if (ids.length > 4) {
@@ -331,4 +257,35 @@ function many (ids, fn) {
       return fn(featuredIds[0])
     }
   }
+}
+
+function getEvent (group) {
+  if (!group.bumps.length) return null
+
+  var msg = group.bumps[0]
+  if (msg.key === group.rootId) {
+    return 'post'
+  } else if (msg.value.content.type === 'post') {
+    return 'reply'
+  } else if (msg.value.content.type === 'vote') {
+    return 'like'
+  }
+}
+
+function getReplyAuthors (group) {
+  return group.bumps.reduce((result, msg) => {
+    if (msg.value.content.type === 'post' && msg.key !== group.rootId) {
+      result.add(msg.value.author)
+    }
+    return result
+  }, new Set())
+}
+
+function getLikeAuthors (group) {
+  return group.bumps.reduce((result, msg) => {
+    if (msg.value.content.type === 'vote') {
+      result.add(msg.value.author)
+    }
+    return result
+  }, new Set())
 }

--- a/modules/feed/html/rollup.js.old
+++ b/modules/feed/html/rollup.js.old
@@ -1,0 +1,334 @@
+var Value = require('mutant/value')
+var when = require('mutant/when')
+var computed = require('mutant/computed')
+var h = require('mutant/h')
+var MutantArray = require('mutant/array')
+var Abortable = require('pull-abortable')
+var map = require('mutant/map')
+var pull = require('pull-stream')
+var nest = require('depnest')
+
+var onceTrue = require('mutant/once-true')
+var Scroller = require('pull-scroll')
+
+exports.needs = nest({
+  'message.html': {
+    render: 'first',
+    link: 'first'
+  },
+  'app.sync.externalHandler': 'first',
+  'sbot.async.get': 'first',
+  'keys.sync.id': 'first',
+  'about.obs.name': 'first',
+  feed: {
+    'html.rollup': 'first',
+    'pull.summary': 'first'
+  },
+  profile: {
+    'html.person': 'first'
+  }
+})
+
+exports.gives = nest({
+  'feed.html': ['rollup']
+})
+
+exports.create = function (api) {
+  return nest({
+    'feed.html': { rollup }
+  })
+  function rollup (getStream, opts) {
+    var sync = Value(false)
+    var updates = Value(0)
+
+    var filter = opts && opts.filter
+    var bumpFilter = opts && opts.bumpFilter
+    var windowSize = opts && opts.windowSize
+    var waitFor = opts && opts.waitFor || true
+
+    var newSinceRefresh = new Set()
+    var newInSession = new Set()
+    var prioritized = {}
+
+    var updateLoader = h('a Notifier -loader', {
+      href: '#',
+      'ev-click': refresh
+    }, [
+      'Show ',
+      h('strong', [updates]), ' ',
+      when(computed(updates, a => a === 1), 'update', 'updates')
+    ])
+
+    var content = Value()
+
+    var container = h('Scroller', {
+      style: { overflow: 'auto' }
+    }, [
+      h('div.wrapper', [
+        h('section.prepend', opts.prepend),
+        when(sync, null, h('Loading -large')),
+        content
+      ])
+    ])
+
+    onceTrue(waitFor, () => {
+      refresh()
+      pull(
+        getStream({old: false}),
+        pull.drain((item) => {
+          var type = item && item.value && item.value.content.type
+
+          // prioritize new messages on next refresh
+          newInSession.add(item.key)
+          newSinceRefresh.add(item.key)
+
+          // ignore message handled by another app
+          if (api.app.sync.externalHandler(item)) return
+
+          if (type && type !== 'vote' && typeof item.value.content === 'object' && item.value.timestamp > twoDaysAgo()) {
+            if (item.value && item.value.author === api.keys.sync.id() && !updates()) {
+              return refresh()
+            }
+            if (filter) {
+              if (item.value.content.type === 'post') {
+                var update = (item.value.content.root) ? {
+                  type: 'message',
+                  messageId: item.value.content.root,
+                  channel: item.value.content.channel
+                } : {
+                  type: 'message',
+                  author: item.value.author,
+                  channel: item.value.content.channel,
+                  messageId: item.key
+                }
+
+                ensureMessageAndAuthor(update, (err, update) => {
+                  if (!err) {
+                    if (filter(update)) {
+                      updates.set(updates() + 1)
+                    }
+                  }
+                })
+              }
+            } else {
+              updates.set(updates() + 1)
+            }
+          }
+        })
+      )
+    })
+
+    var abortLastFeed = null
+
+    var result = MutantArray([
+      when(updates, updateLoader),
+      container
+    ])
+
+    result.reload = refresh
+    result.pendingUpdates = updates
+
+    return result
+
+    // scoped
+
+    function refresh () {
+      if (abortLastFeed) {
+        abortLastFeed()
+      }
+      updates.set(0)
+      sync.set(false)
+
+      content.set(
+        h('section.content', {
+          hidden: computed(sync, s => !s)
+        })
+      )
+
+      var abortable = Abortable()
+      abortLastFeed = abortable.abort
+
+      prioritized = {}
+      newSinceRefresh.forEach(x => {
+        prioritized[x] = 2
+      })
+
+      pull(
+        api.feed.pull.summary(getStream, {windowSize, bumpFilter, prioritized}, () => {
+          sync.set(true)
+        }),
+        pull.asyncMap(ensureMessageAndAuthor),
+        pull.filter((item) => {
+          // ignore messages that are handled by other apps
+          if (item.rootMessage && api.app.sync.externalHandler(item.rootMessage)) return
+          if (filter) {
+            return filter(item)
+          } else {
+            return true
+          }
+        }),
+        abortable,
+        Scroller(container, content(), renderItem, false, false)
+      )
+
+      // clear high prioritized items
+      newSinceRefresh.clear()
+    }
+
+    function renderItem (item) {
+      var classList = []
+      if (item.priority >= 2) {
+        classList.push('-new')
+      }
+
+      if (item.type === 'message') {
+        var meta = null
+        var previousId = item.messageId
+        var replies = item.replies.slice(-4).map((msg) => {
+          var result = api.message.html.render(msg, {
+            inContext: true,
+            inSummary: true,
+            previousId,
+            priority: prioritized[msg.key]
+          })
+          previousId = msg.key
+          return result
+        })
+        var renderedMessage = item.message ? api.message.html.render(item.message, {inContext: true}) : null
+        if (renderedMessage) {
+          if (item.lastUpdateType === 'reply' && item.repliesFrom.size) {
+            meta = h('div.meta', {
+              title: names(item.repliesFrom)
+            }, [
+              many(item.repliesFrom, api.profile.html.person), ' replied'
+            ])
+          } else if (item.lastUpdateType === 'like' && item.likes.size) {
+            meta = h('div.meta', {
+              title: names(item.likes)
+            }, [
+              many(item.likes, api.profile.html.person), ' liked this message'
+            ])
+          }
+
+          return h('FeedEvent', [
+            meta,
+            renderedMessage,
+            when(replies.length, [
+              when(item.replies.length > replies.length || opts.partial,
+                h('a.full', {href: item.messageId}, ['View full thread'])
+              ),
+              h('div.replies', replies)
+            ])
+          ])
+        } else {
+          // when there is no root message in this window,
+          // try and show reply message, only show like message if we have nothing else to give
+          if (item.repliesFrom.size) {
+            meta = h('div.meta', {
+              title: names(item.repliesFrom)
+            }, [
+              many(item.repliesFrom, api.profile.html.person), ' replied to ', api.message.html.link(item.messageId)
+            ])
+          } else if (item.lastUpdateType === 'like' && item.likes.size) {
+            meta = h('div.meta', {
+              title: names(item.likes)
+            }, [
+              many(item.likes, api.profile.html.person), ' liked ', api.message.html.link(item.messageId)
+            ])
+          }
+
+          // only show this event if it has a meta description
+          if (meta) {
+            return h('FeedEvent', [
+              meta, h('div.replies', replies)
+            ])
+          }
+        }
+      } else if (item.type === 'follow') {
+        return h('FeedEvent -follow', {classList}, [
+          h('div.meta', {
+            title: names(item.contacts)
+          }, [
+            api.profile.html.person(item.id), ' followed ', many(item.contacts, api.profile.html.person)
+          ])
+        ])
+      } else if (item.type === 'subscribe') {
+        return h('FeedEvent -subscribe', {classList}, [
+          h('div.meta', {
+            title: names(item.subscribers)
+          }, [
+            many(item.subscribers, api.profile.html.person),
+            ' subscribed to ',
+            h('a', {href: `#${item.channel}`}, `#${item.channel}`)
+          ])
+        ])
+      }
+
+      return h('div')
+    }
+  }
+
+  function ensureMessageAndAuthor (item, cb) {
+    if (item.type === 'message' && !item.message) {
+      if (item.message) {
+        item.rootMessage = item.message
+        cb(null, item)
+      } else {
+        api.sbot.async.get(item.messageId, (_, value) => {
+          if (value) {
+            item.author = value.author
+            item.rootMessage = {key: item.messageId, value}
+          }
+          cb(null, item)
+        })
+      }
+    } else {
+      cb(null, item)
+    }
+  }
+
+  function names (ids) {
+    var items = map(Array.from(ids), api.about.obs.name)
+    return computed([items], (names) => names.map((n) => `- ${n}`).join('\n'))
+  }
+}
+
+function twoDaysAgo () {
+  return Date.now() - (2 * 24 * 60 * 60 * 1000)
+}
+
+function many (ids, fn) {
+  ids = Array.from(ids)
+  var featuredIds = ids.slice(-4).reverse()
+
+  if (ids.length) {
+    if (ids.length > 4) {
+      return [
+        fn(featuredIds[0]), ', ',
+        fn(featuredIds[1]), ', ',
+        fn(featuredIds[2]), ' and ',
+        ids.length - 3, ' others'
+      ]
+    } else if (ids.length === 4) {
+      return [
+        fn(featuredIds[0]), ', ',
+        fn(featuredIds[1]), ', ',
+        fn(featuredIds[2]), ' and ',
+        fn(featuredIds[3])
+      ]
+    } else if (ids.length === 3) {
+      return [
+        fn(featuredIds[0]), ', ',
+        fn(featuredIds[1]), ' and ',
+        fn(featuredIds[2])
+      ]
+    } else if (ids.length === 2) {
+      return [
+        fn(featuredIds[0]), ' and ',
+        fn(featuredIds[1])
+      ]
+    } else {
+      return fn(featuredIds[0])
+    }
+  }
+}

--- a/plugs/message/html/layout/mini.js
+++ b/plugs/message/html/layout/mini.js
@@ -48,7 +48,7 @@ exports.create = (api) => {
       h('header', [
         h('div.mini', [
           api.profile.html.person(msg.value.author), ' ',
-          opts.content
+          opts.miniContent
         ]),
         h('div.meta', {}, [
           api.message.html.meta(msg),
@@ -56,6 +56,7 @@ exports.create = (api) => {
           additionalMeta
         ])
       ]),
+      h('section', [opts.content]),
       footer
     ])
   }

--- a/plugs/message/html/render/about.js
+++ b/plugs/message/html/render/about.js
@@ -25,11 +25,13 @@ exports.create = function (api) {
 
     var c = msg.value.content
     var self = msg.value.author === c.about
+
+    var miniContent = []
     var content = []
 
     if (c.name) {
       var target = api.profile.html.person(c.about, c.name)
-      content.push(computed([self, api.about.obs.name(c.about), c.name], (self, a, b) => {
+      miniContent.push(computed([self, api.about.obs.name(c.about), c.name], (self, a, b) => {
         if (self) {
           return ['self identifies as "', target, '"']
         } else if (a === b) {
@@ -41,9 +43,9 @@ exports.create = function (api) {
     }
 
     if (c.image) {
-      if (!content.length) {
+      if (!miniContent.length) {
         var imageAction = self ? 'self assigned a display image' : ['assigned a display image to ', api.profile.html.person(c.about)]
-        content.push(imageAction)
+        miniContent.push(imageAction)
       }
 
       content.push(h('a AboutImage', {
@@ -55,9 +57,10 @@ exports.create = function (api) {
 
     var elements = []
 
-    if (content.length) {
+    if (miniContent.length) {
       var element = api.message.html.layout(msg, extend({
         showActions: true,
+        miniContent,
         content,
         layout: 'mini'
       }, opts))
@@ -67,10 +70,8 @@ exports.create = function (api) {
     if (c.description) {
       elements.push(api.message.html.decorate(api.message.html.layout(msg, extend({
         showActions: true,
-        content: [
-          self ? 'self assigned a description' : ['assigned a description to ', api.profile.html.person(c.about)],
-          api.message.html.markdown(c.description)
-        ],
+        miniContent: self ? 'self assigned a description' : ['assigned a description to ', api.profile.html.person(c.about)],
+        content: api.message.html.markdown(c.description),
         layout: 'mini'
       }, opts)), { msg }))
     }

--- a/styles/channel-list.mcss
+++ b/styles/channel-list.mcss
@@ -5,6 +5,7 @@ ChannelList {
     font-size: 110%;
     margin: 4px 0;
     background: rgba(255, 255, 255, 0.66);
+    color: #333;
     border-radius: 5px;
     position: relative
     transition: background-color 0.2s

--- a/styles/markdown.mcss
+++ b/styles/markdown.mcss
@@ -7,6 +7,10 @@ Markdown {
     background: #fafafa;
     color: #7c7c7c;
   }
+  (hr) {
+    border: none;
+    border-top: 1px solid #7e7e7e;
+  }
   (pre) {
     overflow: auto;
     padding: 10px;

--- a/styles/split-view.mcss
+++ b/styles/split-view.mcss
@@ -10,7 +10,7 @@ SplitView {
   div.side {
     width: 280px;
     padding: 20px;
-    background: linear-gradient(81deg, #d2f0ff, #ffffff);
+    background: linear-gradient(81deg, #d6ecff, rgb(248, 253, 253));
     border-right: 1px solid #dcdcdc;
     overflow-y: auto;
 


### PR DESCRIPTION
Tracking the progress on this feature.

Here's a quick overview of the new algorithm: 

- In batches of 2000 posts taken from the user asserted timestamps (sbot.feed order), group posts by thread.
- When a thread does not have a root message (in this batch) and it is the public feed, remove all replies from strangers
- Bump threads upwards by most recently received message (sync time, sbot.log order).

It also makes improvements to grouping of "follows" and "friends" trying to reduce the number of feed events needed to communicate the contact changes.

Still to do:

- [ ] filtering (for public feed)
- [ ] channel subscriptions
- [ ] new indexes for channel view (for chronological order)