### PR TITLE
New back button icon and minor header style tweaks

### DIFF
--- a/main-window.js
+++ b/main-window.js
@@ -59,11 +59,11 @@ module.exports = function (config) {
         h('a', {
           'ev-click': views.goBack,
           classList: [ when(views.canGoBack, '-active') ]
-        }, '<'),
+        }),
         h('a', {
           'ev-click': views.goForward,
           classList: [ when(views.canGoForward, '-active') ]
-        }, '>')
+        })
       ]),
       h('span.nav', [
         tab('Public', '/public'),

--- a/styles/base.mcss
+++ b/styles/base.mcss
@@ -1,7 +1,7 @@
 html, body {
   background: #f5f5f5
   margin: 0
-  font-family: -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif
+  font: caption
   overflow: hidden
   height: 100%
   font-size: 12px

--- a/styles/base.mcss
+++ b/styles/base.mcss
@@ -67,20 +67,6 @@ input {
     padding-right: 12px
     border-radius: 0
   }
-  [type='search'] {
-    padding: 4px 8px;
-    border-radius: 3px;
-    border: 0 none;
-    background: #ffffff;
-    color: #656565;
-    font-size: 120%;
-    width: 180px;
-    box-shadow: inset 0 0 0px 1px rgba(0,0,0,0.1)
-    :focus {
-      outline: 0;
-      box-shadow: inset 0 0 0px 1px #286bc3
-    }
-  }
 }
 
 ::-webkit-file-upload-button {

--- a/styles/base.mcss
+++ b/styles/base.mcss
@@ -1,7 +1,7 @@
 html, body {
   background: #f5f5f5
   margin: 0
-  font-family: caption, sans-serif
+  font-family: -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'helvetica neue', helvetica, ubuntu, roboto, noto, 'segoe ui', arial, sans-serif
   overflow: hidden
   height: 100%
   font-size: 12px
@@ -66,6 +66,20 @@ input {
     color: #FFF
     padding-right: 12px
     border-radius: 0
+  }
+  [type='search'] {
+    padding: 4px 8px;
+    border-radius: 3px;
+    border: 0 none;
+    background: #ffffff;
+    color: #656565;
+    font-size: 120%;
+    width: 180px;
+    box-shadow: inset 0 0 0px 1px rgba(0,0,0,0.1)
+    :focus {
+      outline: 0;
+      box-shadow: inset 0 0 0px 1px #286bc3
+    }
   }
 }
 

--- a/styles/main-window.mcss
+++ b/styles/main-window.mcss
@@ -19,6 +19,23 @@ MainWindow {
     position: relative;
     z-index: 100
 
+    span {
+      input.search {
+        padding: 4px 8px;
+        border-radius: 3px;
+        border: 0 none;
+        background: #ffffff;
+        color: #656565;
+        font-size: 120%;
+        width: 180px;
+        box-shadow: inset 0 0 0px 1px rgba(0,0,0,0.1)
+        :focus {
+          outline: 0;
+          box-shadow: inset 0 0 0px 1px #286bc3
+        }
+      }
+    }
+
     span.history {
       padding-left: 6px
       height: 26px;

--- a/styles/main-window.mcss
+++ b/styles/main-window.mcss
@@ -11,46 +11,80 @@ MainWindow {
 
   div.top {
     display: flex;
+    align-items: center;
     background: #fff;
-    padding: 10px;
+    padding: 6px;
     border-bottom: 2px solid #e4edff;
     box-shadow: 0 0 3px #7f7f7f;
     position: relative;
     z-index: 100
 
-    span {
-
-      input.search {
-        padding: 2px 4px;
-        border: 01px solid #c7c6c6;
-        border-radius: 4px;
-        background: #ffffff;
-        color: #656565;
-        font-size: 120%;
-        margin-top: -3px;
-        width: 180px;
+    span.history {
+      padding-left: 6px
+      height: 26px;
+      display: inline-block
+      a {
+        cursor: pointer;
+        text-decoration: none !important
+        display: inline-block
+        width: 28px
+        height: 100%
+        border-radius: 2px
+        background: svg(backArrow) no-repeat center
+        opacity: 0.4
+        -active {
+          opacity: 1
+        }
+        :hover {
+          background-color: #E8E8E8
+        }
       }
 
+      a + a {
+        transform: rotate(180deg)
+      }
+
+      @svg backArrow {
+        width: 14px
+        height: 14px
+        content: '<g stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M1.5 7h11M7 13L1 7l6-6"/></g>'
+
+        path {
+          stroke: #979797
+        }
+
+        -active {
+          path {
+            fill: #DDD
+          }
+        }
+      }
+    }
+
+    span.nav {
+      display: inline-block
       a {
-        padding: 2px 8px;
-        border: 2px solid #c7c6c6;
-        border-radius: 4px;
-        background: #dedede;
+        padding: 4px 10px;
+        border-radius: 3px;
+        background: #f3f3f3;
         color: #656565;
         font-size: 120%;
+        font-weight: 200;
         cursor: pointer;
-        margin-left: 5px;
+        margin-left: 8px;
         text-decoration: none !important
 
         :hover {
           color: black
-          border-color: #888
+          background: #E8E8E8
         }
 
         -selected {
-          border-color: #444
-          background: #CCC
+          background: #d2d2d2
           color: black
+          :hover {
+            background: #d2d2d2
+          }
         }
 
         -add {
@@ -71,28 +105,13 @@ MainWindow {
       }
     }
 
-    span.history {
-      a {
-        opacity: 0.3
-
-        -active {
-          opacity: 1
-        }
-      }
-
-      a + a {
-        margin-left: 0
-      }
-    }
-
     span.appTitle {
       flex: 1;
       text-align: center;
-      font-size: 130%;
+      font-size: 20px;
       color: #757575;
-      letter-spacing: 0.1em;
-      font-weight: bold;
-      font-weight: normal;
+      letter-spacing: 1px;
+      font-weight: 200;
       -webkit-app-region: drag;
     }
   }


### PR DESCRIPTION
Minor improvements to the header nav styles.

- Fix the default font. (`caption` is a shorthand value for `font` rather than `font-family`)
- New back and forward nav icons, arrow svgs, in the style of chromium.
- Simplify the nav tab buttons.
- Center align the things
- Tweak search input. ~~The existing `input.search` styles were't getting applied. I had to pull them into the base.mcss to get them to apply. If can explain the mcss build process I might be able to fix that.~~ Got it working. Not sure why I need to explicitly mirror the html structure in the css though.

![screenshot 2017-04-22 21 10 10](https://cloud.githubusercontent.com/assets/58871/25307918/b6946e12-27a1-11e7-9062-d6c9b22b78a0.png)

| Before | After |
|-------|-------|
| ![screenshot 2017-04-22 21 16 45](https://cloud.githubusercontent.com/assets/58871/25307871/0990e7f4-27a1-11e7-8968-c0efc5408850.png) | ![screenshot 2017-04-22 21 10 10](https://cloud.githubusercontent.com/assets/58871/25307870/0990c06c-27a1-11e7-9e4a-0f8957e07a22.png) |
