### PR TITLE
Message ui tweaks

### DIFF
--- a/plugs/message/html/meta/likes.js
+++ b/plugs/message/html/meta/likes.js
@@ -17,7 +17,7 @@ exports.create = function (api) {
     if (likes.length) {
       return [' ', h('span.likes', {
         title: names(likes)
-      }, ['+', h('strong', `${likes.length}`)])]
+      }, [`${likes.length} ${likes.length === 1 ? 'like' : 'likes'}`])]
     }
   }
 

--- a/styles/feed-event.mcss
+++ b/styles/feed-event.mcss
@@ -2,10 +2,10 @@ FeedEvent {
   display: flex
   flex-direction: column
   background: white
-  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1)
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1)
   max-width: 700px
   width: 100%
-  margin: 0 auto 25px
+  margin: 25px auto
 
   -new {
     box-shadow: 0px 0px 2px #ffc800;
@@ -19,11 +19,10 @@ FeedEvent {
   a.full {
     display: block;
     padding: 10px;
-    background: #daecd6;
+    background: f3fafd;
     border-top: 1px solid #bbc9d2;
     border-bottom: 1px solid #bbc9d2;
     text-align: center;
-    color: #759053;
   }
 
   div.replies {

--- a/styles/feed-event.mcss
+++ b/styles/feed-event.mcss
@@ -2,9 +2,10 @@ FeedEvent {
   display: flex
   flex-direction: column
   background: white
+  box-shadow: 0 0 4px 1px rgba(0,0,0,0.1)
   max-width: 700px
   width: 100%
-  margin: 10px auto
+  margin: 0 auto 25px
 
   -new {
     box-shadow: 0px 0px 2px #ffc800;
@@ -37,6 +38,10 @@ FeedEvent {
 
   div.meta {
     font-size: 100%
-    padding: 10px
+    padding: 10px 20px
+    opacity: 0.4
+    :hover {
+      opacity: 0.8
+    }
   }
 }

--- a/styles/message.mcss
+++ b/styles/message.mcss
@@ -1,11 +1,10 @@
 Message {
   display: flex
   flex-direction: column
-  box-shadow: #dadada 1px 2px 8px
-  border: 1px solid #f5f5f5
   background: white
   position: relative
-  font-size: 130%
+  font-size: 120%
+  line-height: 1.4
   flex-shrink: 0
 
   (highlight) {
@@ -54,7 +53,8 @@ Message {
       div.main {
         a.avatar {
           img {
-            width: 35px
+            width: 40px
+            height: 40px
           }
         }
       }
@@ -66,8 +66,7 @@ Message {
   }
 
   header {
-    margin: 15px 15px
-    margin-bottom: 5px;
+    margin: 10px 20px 0
     display: flex
 
     div.mini {
@@ -81,6 +80,7 @@ Message {
       a.avatar {
         img {
           width: 50px
+          height: 50px
         }
       }
 
@@ -133,13 +133,13 @@ Message {
       }
 
       span.likes {
-        color: #ffffff;
-        background: linear-gradient(45deg, #859c88, #87d47d);
-        padding: 5px 8px;
-        border-radius: 10px;
-        display: inline-block;
-        vertical-align: top;
-        margin: -2px 0;
+        margin-right: 10px;
+        color: #286bc3;
+        font-weight: 200;
+        strong {
+          color: #286bc3;
+          font-weight: 200;
+        }
       }
 
       span.private {
@@ -201,18 +201,14 @@ Message {
   }
 
   footer {
-    margin: 10px 10px;
-    border-top: 1px solid #eee;
-    padding-top: 10px;
-    margin-top: 5px;
-    padding-left: 5px;
+    margin: 5px 10px 20px;
 
     div.actions {
       a {
-        margin-right: 10px;
         color: #9a9a9a;
-        font-weight: bold;
-        padding: 5px
+        font-weight: 200;
+        padding: 5px 10px;
+        border-radius:2px;
 
         :hover {
           background: #cbeeff;
@@ -220,6 +216,9 @@ Message {
           text-decoration: none;
           border-color: #8eafc1;
         }
+      }
+      a + a {
+        margin-left: 15px;
       }
     }
   }

--- a/styles/message.mcss
+++ b/styles/message.mcss
@@ -50,6 +50,11 @@ Message {
   -reply {
     font-size: 120%
     header {
+      div.meta {
+        a.channel {
+          display: none;
+        }
+      }
       div.main {
         a.avatar {
           img {
@@ -66,7 +71,7 @@ Message {
   }
 
   header {
-    margin: 10px 20px 0
+    margin: 15px 20px 0
     display: flex
 
     div.mini {
@@ -86,7 +91,6 @@ Message {
 
       div.main {
         div.name {
-          font-size: 120%
           a {
             color: #444
             font-weight: bold
@@ -100,6 +104,10 @@ Message {
     }
 
     div.meta {
+      display: flex;
+      flex-direction: column-reverse;
+      align-items: flex-end;
+      justify-content: flex-end;
 
       span.flag {
         width: 12px
@@ -128,18 +136,12 @@ Message {
       }
 
       a.channel {
-        display: inline-block
-        padding: 4px
+        font-weight: bold;
       }
 
       span.likes {
-        margin-right: 10px;
         color: #286bc3;
-        font-weight: 200;
-        strong {
-          color: #286bc3;
-          font-weight: 200;
-        }
+        font-size:90%;
       }
 
       span.private {
@@ -177,7 +179,8 @@ Message {
   }
 
   section {
-    margin: 0 15px
+    margin: 0
+    padding: 0 20px
     (img) {
       max-width: 100%
     }
@@ -201,24 +204,19 @@ Message {
   }
 
   footer {
-    margin: 5px 10px 20px;
+    margin: 5px 0 20px;
+    padding: 0 20px
 
     div.actions {
       a {
-        color: #9a9a9a;
-        font-weight: 200;
-        padding: 5px 10px;
-        border-radius:2px;
-
+        opacity: 0.4
         :hover {
-          background: #cbeeff;
-          color: #3b7ba2;
+          opacity: 1
           text-decoration: none;
-          border-color: #8eafc1;
         }
       }
       a + a {
-        margin-left: 15px;
+        margin-left: 25px;
       }
     }
   }


### PR DESCRIPTION
This PR visually simplifies the message and feed-item layout for much calm

- Move card style box shadow to the parent FeedEvent
- Tweak message line-height for readability.
- Fewer border lines. Scuttlebutt knows no borders.
- Tweak padding to visually cluster things.
- Hide repeated `#channel` header in replies.
- Simplify the likes backdown to a regular header meta style... I'd be up for porting the V fingers, from patchwork-classic over to patchwork in another PR if people are up for that. It's rad.

![screenshot 2017-04-23 19 30 38](https://cloud.githubusercontent.com/assets/58871/25316253/689faa90-285b-11e7-9fbd-4d03946ac7ed.png)

| Before | After |
|--------|------|
| ![screenshot 2017-04-23 19 24 42](https://cloud.githubusercontent.com/assets/58871/25316226/a006320c-285a-11e7-8439-db4959bb0c88.png) | ![screenshot 2017-04-23 19 30 38](https://cloud.githubusercontent.com/assets/58871/25316253/689faa90-285b-11e7-9fbd-4d03946ac7ed.png) |


