### PR TITLE
Add custom Window menu with Zoom option

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,16 @@ electron.app.on('ready', () => {
       { type: 'separator' },
       { role: 'togglefullscreen' }
     ]
+    if (process.platform === 'darwin') {
+      var win = menu.find(x => x.label === 'Window')
+      win.submenu = [
+        { role: 'minimize' },
+        { role: 'zoom' },
+        { role: 'close', label: 'Close' },
+        { type: 'separator' },
+        { role: 'front' }
+      ]
+    }
     Menu.setApplicationMenu(Menu.buildFromTemplate(menu))
     openMainWindow()
   })


### PR DESCRIPTION
This PR adds the **Zoom** option to the **Window** menu on macOS:

<img width="665" alt="screen_shot_2017-04-27_at_16_53_09" src="https://cloud.githubusercontent.com/assets/15045/25506013/137c10b4-2b6a-11e7-983a-2e6ccd8afb8e.png">

(I think the **Zoom All** and **Bring All to Front** options are there because of the hidden background window where the server process runs).

