### PR TITLE
disable electron-spellchecker to make build simpler

### DIFF
--- a/main-window.js
+++ b/main-window.js
@@ -10,7 +10,7 @@ var insertCss = require('insert-css')
 var nest = require('depnest')
 var LatestUpdate = require('./lib/latest-update')
 var ref = require('ssb-ref')
-var setupContextMenuAndSpellCheck = require('./lib/context-menu-and-spellcheck')
+//var setupContextMenuAndSpellCheck = require('./lib/context-menu-and-spellcheck')
 
 module.exports = function (config) {
   var sockets = combine(
@@ -37,7 +37,7 @@ module.exports = function (config) {
     'app.navigate': 'first'
   }))
 
-  setupContextMenuAndSpellCheck(api.config.sync.load())
+  //setupContextMenuAndSpellCheck(api.config.sync.load())
 
   var id = api.keys.sync.id()
   var latestUpdate = LatestUpdate()

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "depject": "^3.2.0",
     "depnest": "^1.0.2",
     "electron-default-menu": "~1.0.0",
-    "electron-spellchecker": "^1.0.4",
     "electron-window-state": "^4.1.0",
     "has-network": "0.0.0",
     "insert-css": "~1.0.0",
@@ -67,3 +66,4 @@
     "electron": "~1.4.4"
   }
 }
+


### PR DESCRIPTION
@av8ta told me that he was having trouble building patchwork, I had previously been unable to build it because of electron-spellchecker. (and does it really justify the complexity of a native addon?)

So, don't merge this, but @av8ta is this buildable for you?