### PR TITLE
update level to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "has-network": "0.0.0",
     "insert-css": "~1.0.0",
     "is-visible": "^2.1.1",
-    "level": "~1.6.0",
+    "level": "~1.7.0",
     "level-memview": "0.0.0",
     "map-filter-reduce": "~3.0.3",
     "micro-css": "^2.0.0",


### PR DESCRIPTION
This will pull in `leveldown@1.7.0` which contains leveldb version 1.20 and snappy 1.1.4. Also, we have prebuilt versions for electron on linux, osx and windows, see https://github.com/Level/leveldown/releases/tag/v1.7.0 for more info

![screenshot from 2017-05-17 17-27-03](https://cloud.githubusercontent.com/assets/308049/26162112/1f24f4be-3b26-11e7-8938-d101443cdc70.png)
