### PR TITLE
fix rebuild script to work cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron index.js",
     "postinstall": "npm run rebuild",
-    "rebuild": "cross-script npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell"
+    "rebuild": "cross-script npm rebuild --runtime=electron \"--target=$(electron -v)\" \"--abi=$(electron --abi)\" --disturl=https://atom.io/download/atom-shell"
   },
   "author": "Secure Scuttlebutt Consortium",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron index.js",
     "postinstall": "npm run rebuild",
-    "rebuild": "cross-script npm rebuild --runtime=electron '--target=$(electron -v)' '--abi=$(electron --abi)' --disturl=https://atom.io/download/atom-shell"
+    "rebuild": "cross-script npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell"
   },
   "author": "Secure Scuttlebutt Consortium",
   "license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron index.js",
     "postinstall": "npm run rebuild",
-    "rebuild": "npm rebuild --runtime=electron --target=$(electron -v) --abi=$(electron --abi) --disturl=https://atom.io/download/atom-shell"
+    "rebuild": "cross-script npm rebuild --runtime=electron '--target=$(electron -v)' '--abi=$(electron --abi)' --disturl=https://atom.io/download/atom-shell"
   },
   "author": "Secure Scuttlebutt Consortium",
   "license": "GPL-3.0",
@@ -18,6 +18,7 @@
     "bulk-require": "^1.0.0",
     "catch-links": "^2.0.1",
     "compare-version": "^0.1.2",
+    "cross-script": "^1.0.1",
     "data-uri-to-buffer": "0.0.4",
     "deep-equal": "^1.0.1",
     "depject": "^3.2.0",


### PR DESCRIPTION
wrote a silly module to fix our windoze woes: [`cross-script`](https://github.com/ahdinosaur/cross-script)

- fixes bug introduced in https://github.com/ssbc/patchwork/pull/513
- reference: https://github.com/ssbc/patchwork/pull/535

TODO

- [x] test on windows
- [x] test on linux
- [x] test on mac
- [ ] test on bsd?