### PR TITLE
upgrade `scuttlebot` to `~10.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pull-pushable": "^2.0.1",
     "pull-scroll": "^1.0.4",
     "pull-stream": "~3.4.5",
-    "scuttlebot": "~10.0.0",
+    "scuttlebot": "~10.0.5",
     "sorted-array-functions": "~1.0.0",
     "ssb-avatar": "^0.2.0",
     "ssb-blobs": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "pull-pushable": "^2.0.1",
     "pull-scroll": "^1.0.4",
     "pull-stream": "~3.4.5",
-    "scuttlebot": "github:ssbc/scuttlebot#flume",
+    "scuttlebot": "~10.0.0",
     "sorted-array-functions": "~1.0.0",
     "ssb-avatar": "^0.2.0",
     "ssb-blobs": "~1.0.1",


### PR DESCRIPTION
otherwise get error

```
npm ERR! path /home/dinosaur/repos/ssbc/patchwork/node_modules/scuttlebot/sbot.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod
npm ERR! enoent ENOENT: no such file or directory, chmod '/home/dinosaur/repos/ssbc/patchwork/node_modules/scuttlebot/sbot.js'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 
```

trying to use early `flume` branch :smile_cat: 