### PR TITLE
Start ssb-notifier if installed

### DIFF
--- a/server-process.js
+++ b/server-process.js
@@ -44,4 +44,15 @@ module.exports = function (ssbConfig) {
   process.on('exit', () => {
     gitSsb.kill()
   })
+  
+   // attempt to run ssb-notifier if it is installed and in path
+  var ssbNotifier = spawn('ssb-notifier', {
+    stdio: 'inherit'
+  })
+  ssbNotifier.on('error', () => {
+    console.log('ssb-notifier is not installed, or not available in path')
+  })
+  process.on('exit', () => {
+    ssbNotifier.kill()
+  })
 }


### PR DESCRIPTION
As per git-ssb start ssb-notifier if it is installed.

Idea here being to replicate the behavior of git-ssb and autostart as background process the notifier.

I have had it running like this for a week or so. At this stage with two additional services potentially starting automatically in the background (git-ssb and ssb-notifier) perhaps a UI menu where they can be enabled/disabled is needed.

I get few messages so notifications for me are infrequent, more busy users may find the notifications intrusive perhaps? So this patch perhaps not desired in grander scheme of the project?

Consider this perhaps a discussion starter?