### PR TITLE
only count mentions for badge count

### DIFF
--- a/main-window.js
+++ b/main-window.js
@@ -60,8 +60,7 @@ module.exports = function (config) {
   ])
 
   var pendingCount = computed([
-    views.get('/mentions').pendingUpdates,
-    views.get('/private').pendingUpdates
+    views.get('/mentions').pendingUpdates
   ], (...counts) => {
     return counts.reduce((a, b) => a + b)
   })

--- a/main-window.js
+++ b/main-window.js
@@ -59,11 +59,7 @@ module.exports = function (config) {
     '/public', '/private', id, '/mentions'
   ])
 
-  var pendingCount = computed([
-    views.get('/mentions').pendingUpdates
-  ], (...counts) => {
-    return counts.reduce((a, b) => a + b)
-  })
+  var pendingCount = views.get('/mentions').pendingUpdates
 
   watch(pendingCount, count => {
     electron.remote.app.setBadgeCount(count)

--- a/main-window.js
+++ b/main-window.js
@@ -60,7 +60,7 @@ module.exports = function (config) {
   ])
 
   var pendingCount = computed([
-    views.get('/public').pendingUpdates,
+    views.get('/mentions').pendingUpdates,
     views.get('/private').pendingUpdates
   ], (...counts) => {
     return counts.reduce((a, b) => a + b)


### PR DESCRIPTION
I feel the red badge over the icon in the tray should show updates when they're relevant to you, not just any new updates anywhere on the network not yet viewed.

Just counting mentions should include private messages also