### PR TITLE
Dark theme upgrades and fixes

### DIFF
--- a/styles/dark/gathering-card.mcss
+++ b/styles/dark/gathering-card.mcss
@@ -1,7 +1,7 @@
 GatheringCard {
-  border: 1px solid #DDD
-  padding: 10px
-  margin-bottom: 10px
+  padding: 20px
+  margin: 20px -20px
+  border-top: 1px solid #2d2c2c
 
   a.image {
     display: block
@@ -17,23 +17,34 @@ GatheringCard {
     padding-top: 10px;
 
     div.title {
-      font-size: 90%;
-      color: #555;
-      font-weight: bold;
+      font-size: 75%;
       margin-bottom: 10px;
+      text-align: center
     }
     div.attendees {
-      margin: 0 5px
-      a {
-        margin-right: 4px
-        img {
-          height: 45px
-          width: 45px
-        }
+      text-align: center
+
+      a + a {
+        margin-left: 10px
+      }
+
+      (img) {
+        height: 45px
+        width: 45px
+        border-radius: 3px
       }
     }
     div.actions {
+      text-align: center
       margin-top: 10px
+
+      button {
+        :first-child {
+          ::before {
+            content: '✔ '
+          }
+        }
+      }
       button + button {
         margin-left: 5px
       }
@@ -41,18 +52,23 @@ GatheringCard {
   }
 
   div.title {
-    font-size: 200%
+    a {
+      font-size: 200%
+    }
     button {
       float: right;
-      font-size: 60%;
+
+      ::before {
+        content: '✎ '
+      }
     }
   }
   div.time {
-    color: #555
-    font-size: 120%
+    color: #757474
   }
   div.description {
-    border-top: 3px solid #CCC;
-    margin-top: 10px;
+    margin: 20px 0 0
+    padding: 20px
+    background: #2d2c2c
   }
 }

--- a/styles/dark/markdown.mcss
+++ b/styles/dark/markdown.mcss
@@ -66,24 +66,22 @@ Markdown {
     margin-bottom: -0.3em;
   }
 
-  p {
-    (a) {
-      color: #6f74e5
+  (a) {
+    color: #6f74e5
+    :hover {
+      text-decoration: underline;
+    }
+    [href^="@"] {
+      color: #efef00
+      border-bottom: 1px dotted #efef00
       :hover {
-        text-decoration: underline;
+        text-decoration: none;
       }
-      [href^="@"] {
-        color: #efef00
-        border-bottom: 1px dotted #efef00
-        :hover {
-          text-decoration: none;
-        }
-      }
-      [href^="#"] {
-        color: #c1cdf0
-        :hover {
-          text-decoration: none;
-        }
+    }
+    [href^="#"] {
+      color: #c1cdf0
+      :hover {
+        text-decoration: none;
       }
     }
   }

--- a/styles/dark/message.mcss
+++ b/styles/dark/message.mcss
@@ -157,6 +157,10 @@ Message {
       a.likes {
         font-size: 75%;
 
+        ::before {
+          content: '❤ '
+          color: #ff2f92
+        }
         :hover {
           color: #ff2f92
         }

--- a/styles/dark/message.mcss
+++ b/styles/dark/message.mcss
@@ -35,7 +35,7 @@ Message {
   -mini {
     header {
       font-size: 100%
-      margin-bottom: 15px
+
       div.main {
         a.avatar {
           img {
@@ -130,16 +130,14 @@ Message {
         background-position: center
         display: inline-block
         vertical-align: middle;
-        margin-top: -3px;
 
         -new {
-          background-image: svg(new)
-        }
-
-        @svg new {
-          width: 12px
-          height: 12px
-          content: "<circle cx='6' stroke='none' fill='#efef00' cy='6' r='5' />"
+          width: auto
+          height: auto
+          :before {
+            content: '✸ new'
+            font-size: 75%
+          }
         }
       }
 

--- a/styles/dark/message.mcss
+++ b/styles/dark/message.mcss
@@ -134,9 +134,19 @@ Message {
         -new {
           width: auto
           height: auto
+          color: #757474
+
           :before {
             content: '✸ new'
             font-size: 75%
+          }
+
+          :hover {
+            color: #efef00
+          }
+
+          :first-letter {
+            color: #efef00
           }
         }
       }


### PR DESCRIPTION
Some upgrades and fixes for the dark theme. Highlights:

Gatherings styles:
![screen shot 2017-09-19 at 10 34 21](https://user-images.githubusercontent.com/152863/30717917-3b22c9ee-9f16-11e7-8a73-187426336abf.png)

Heart icon next to likes:
<img width="711" alt="screen shot 2017-09-19 at 10 32 20" src="https://user-images.githubusercontent.com/152863/30717885-3230ba30-9f16-11e7-8324-a604f16b729d.png">

New flag styles:
<img width="716" alt="screen shot 2017-09-19 at 10 32 09" src="https://user-images.githubusercontent.com/152863/30717870-1f036d40-9f16-11e7-87f9-c3dfb5c86a5d.png">
