### PR TITLE
Downgrade electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "text-node-searcher": "^1.1.1"
   },
   "devDependencies": {
-    "electron": "~1.7.6"
+    "electron": "1.6.13"
   }
 }


### PR DESCRIPTION
When adding Travis CI in #629, I noticed that [Electron 1.7.8 releases are not available for linux](https://github.com/electron/electron/issues/10595).  I downgraded to 1.6.13 and the build went green.

- before: https://travis-ci.org/harlantwood/patchwork/builds/279139717
- after: https://travis-ci.org/harlantwood/patchwork/builds/279140955

Disclaimer: I'm new here, so please only merge this if we have no concerns about reverting to electron v1.6.x.