### PR TITLE
Updated Debian dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: node_js
 before_install:
   - npm install -g npm@latest
   - sudo apt-get -qq update
-  - sudo apt-get install -y g++ m4 libtool automake                 # build tools
+  - sudo apt-get install -y g++ m4 libtool automake libgconf-2-4    # build tools
   - sudo apt-get install -y libxext-dev libxtst-dev libxkbfile-dev  # spellchecker headers
 
 node_js:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You'll need some more dependencies to build.
 On Debian Linux:
 
 ```shell
-sudo apt-get install g++ m4 libtool automake # build tools
+sudo apt-get install g++ m4 libtool automake libgconf-2-4   # build tools
 sudo apt-get install libxext-dev libxtst-dev libxkbfile-dev # spellchecker headers
 ```
 On Fedora Linux:


### PR DESCRIPTION
I was unable to run Patchwork in Debian due to a missing dependency in Electron. After following the instructions in the README I was greeted by this error:

```
rachel@rachel76:~/Projects/Misc/patchwork$ npm start

> ssb-patchwork@3.7.1 start /home/rachel/Projects/Misc/patchwork
> electron index.js

error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
```

I was able to fix this by installing `libgconf-2-4`, so I added it to the dependencies in the README file. 

According to this issue in Electron https://github.com/electron/electron/issues/1518 libgconf has been a dependency on Linux since 2015.