### PR TITLE
add patch-drafts

### DIFF
--- a/main-window.js
+++ b/main-window.js
@@ -20,6 +20,7 @@ module.exports = function (config) {
     require('./modules'),
     require('./plugs'),
     require('patch-settings'),
+    require('patch-drafts'),
     require('patchcore'),
     require('./overrides')
   )

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mutant": "^3.21.2",
     "mutant-pull-reduce": "^1.1.0",
     "obv": "0.0.1",
+    "patch-drafts": "0.0.5",
     "patch-settings": "^1.0.1",
     "patchcore": "~1.16.0",
     "pull-abortable": "^4.1.0",


### PR DESCRIPTION
This adds draft persistence using localStorage to the message composer.

See [%htLjFxun2o6T4Ow4/8+fqnL7KVoBO0CSh7gLSXafnNY=.sha256](https://viewer.scuttlebot.io/%25htLjFxun2o6T4Ow4%2F8%2BfqnL7KVoBO0CSh7gLSXafnNY%3D.sha256)