### PR TITLE
Adding patchwork version information to the settings screen

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -196,5 +196,6 @@
 		"one": "%s person from your network replied to this message on ",
 		"other": "%s people from your network replied to this message on "
 	},
-	"(you)": "(you)"
+	"(you)": "(you)",
+	"Information": "Information"
 }

--- a/modules/page/html/render/settings.js
+++ b/modules/page/html/render/settings.js
@@ -1,5 +1,6 @@
 var { h, when } = require('mutant')
 var nest = require('depnest')
+var packageInfo = require('../../../../package.json')
 
 var themeNames = Object.keys(require('../../../../styles'))
 
@@ -92,6 +93,12 @@ exports.create = function (api) {
                 label: i18n('Only include posts from subscribed channels')
               })
             ])
+          ]),
+
+          h('section', [
+            h('h2', i18n('Information')),
+
+            h('p', `${packageInfo.productName} ${packageInfo.version}`)
           ])
         ])
       ])


### PR DESCRIPTION
This PR adds a new section on the settings screen showing information about the running patchwork. Currently it only displays the version.

![patchwork 2017-12-16 12 40 37](https://user-images.githubusercontent.com/23247/34071505-54281936-e25e-11e7-83f6-8a5e0d789f47.png)

I added that because I had trouble figuring out which version I was running on Windows 10 where the _about_ menu that is displayed on macOS is not available.