### PR TITLE
[WIP] Find in page

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,17 +104,6 @@ function openMainWindow () {
       windows.main = null
       if (process.platform !== 'darwin') electron.app.quit()
     })
-    electron.ipcMain.on('findInPage', (event, search) => {
-      console.log('findInPage', {search})
-      windows.main.webContents.findInPage(search)
-    })
-    windows.main.webContents.on('found-in-page', (event, result) => {
-      console.log('found-in-page', { result })
-      if (result.finalUpdate) {
-        windows.main.webContents.stopFindInPage('keepSelection')
-      }
-      windows.main.webContents.send('found-in-page', result)
-    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -104,6 +104,17 @@ function openMainWindow () {
       windows.main = null
       if (process.platform !== 'darwin') electron.app.quit()
     })
+    electron.ipcMain.on('findInPage', (event, search) => {
+      console.log('findInPage', {search})
+      windows.main.webContents.findInPage(search)
+    })
+    windows.main.webContents.on('found-in-page', (event, result) => {
+      console.log('found-in-page', { result })
+      if (result.finalUpdate) {
+        windows.main.webContents.stopFindInPage('keepSelection')
+      }
+      windows.main.webContents.send('found-in-page', result)
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ electron.app.on('ready', () => {
       { type: 'separator' },
       { role: 'togglefullscreen' }
     ]
+    var win = menu.find(x => x.label === 'Window')
     if (process.platform === 'darwin') {
-      var win = menu.find(x => x.label === 'Window')
       win.submenu = [
         { role: 'minimize' },
         { role: 'zoom' },
@@ -45,6 +45,13 @@ electron.app.on('ready', () => {
         { role: 'front' }
       ]
     }
+    win.submenu.push({
+      label: 'Find in Page',
+      accelerator: 'CmdOrCtrl+F',
+      click() {
+        windows.main.webContents.send('showSearch')
+      }
+    })
     Menu.setApplicationMenu(Menu.buildFromTemplate(menu))
     openMainWindow()
   })

--- a/main-window.js
+++ b/main-window.js
@@ -33,6 +33,7 @@ module.exports = function (config) {
     'page.html.render': 'first',
     'app.html.search': 'first',
     'app.html.channels': 'first',
+    'app.html.findInPage': 'first',
     'app.views': 'first',
     'app.sync.externalHandler': 'first',
     'app.html.progressNotifier': 'first',
@@ -131,6 +132,7 @@ module.exports = function (config) {
         ])
       ])
     ),
+    api.app.html.findInPage(views),
     views.html
   ])
 

--- a/modules/app/find-in-page.js
+++ b/modules/app/find-in-page.js
@@ -19,32 +19,30 @@ const EscapeHook = (obs, value) => element => {
 
 exports.gives = nest('app.html.findInPage')
 
-// exports.needs = nest({
-//   'app.views': 'first'
-// })
-
 exports.create = function (api) {
   return nest('app.html.findInPage', function (views) {
     const shown = Value(false)
     const searchString = Value('')
-    const resultCount = Value(null)
-
-    window.searchString = searchString
+    const resultCount = Value(0)
+    const currentMatchNum = Value(0)
 
     ipcRenderer.on('showSearch', () => shown.set(true))
     views.currentView(() => shown.set(false))
 
-    ipcRenderer.on('found-in-page', (event, result) => {
-      resultCount.set(result.matches - 1)
-      console.log('found-in-page',{ event, result })
-    })
+    // views.html.addEventListener('found-in-page', ({ result }) => {
+    //   const {activeMatchOrdinal, finalUpdate, matches} = result
+    //   currentMatchNum.set(activeMatchOrdinal)
+    //   resultCount.set(matches)
+    //   console.log('found-in-page', { activeMatchOrdinal, finalUpdate, matches })
+    // })
 
     searchString(search => {
       if (search.length > 0) {
-        console.log('sending', search)
-        ipcRenderer.send('findInPage', search)
+        // console.log('sending', search)
+        window.find(search, false, false, true, false, true, true)
       } else {
-        resultCount.set(null)
+        resultCount.set(0)
+        currentMatchNum.set(0)
       }
     })
 
@@ -57,7 +55,6 @@ exports.create = function (api) {
     shown(val => {
       if (val) {
         setTimeout(() => {
-          console.log('focusing')
           input.focus()
           input.select()
         }, 5)
@@ -66,7 +63,7 @@ exports.create = function (api) {
     return h('div', when(shown,
       h('div.search', [
         input,
-        h('span.count', resultCount)
+        when(searchString, h('span.count', [currentMatchNum, '/' , resultCount]))
       ])
     ))
 })

--- a/modules/app/find-in-page.js
+++ b/modules/app/find-in-page.js
@@ -1,0 +1,71 @@
+var {remote, shell, clipboard, ipcRenderer, webContents } = require('electron')
+var nest = require('depnest')
+var { h, Value, computed, Struct, when } = require('mutant')
+
+var {MenuItem, Menu} = remote
+
+const ValueHook = (obs) => function (element) {
+  element.value = obs()
+  element.oninput = () => {
+    obs.set(element.value.trim())
+  }
+}
+
+const EscapeHook = (obs, value) => element => {
+  element.onkeydown = event => {
+    event.key === 'Escape' && obs.set(value)
+  }
+}
+
+exports.gives = nest('app.html.findInPage')
+
+// exports.needs = nest({
+//   'app.views': 'first'
+// })
+
+exports.create = function (api) {
+  return nest('app.html.findInPage', function (views) {
+    const shown = Value(false)
+    const searchString = Value('')
+    const resultCount = Value(null)
+
+    ipcRenderer.on('showSearch', () => shown.set(true))
+    views.currentView(() => shown.set(false))
+
+    // webContents.on('found-in-page', (event, result) => {
+    //   resultCount.set(result.matches)
+    //   // if (result.finalUpdate) webContents.stopFindInPage('clearSelection')
+    // })
+
+    searchString(search => {
+      console.log('searching for', search, [views.html])
+      if (search.length > 0) {
+        webContents.findInPage(search)
+      } else {
+        resultCount.set(null)
+      }
+    })
+
+    const input = h('input', {
+      type: 'search',
+      value: searchString,
+      hooks: [ValueHook(searchString), EscapeHook(shown, false)],
+    })
+
+    shown(val => {
+      if (val) {
+        setTimeout(() => {
+          console.log('focusing')
+          input.focus()
+          input.select()
+        }, 5)
+      }
+    })
+    return h('div', when(shown,
+      h('div.search', [
+        input,
+        h('span.count', resultCount)
+      ])
+    ))
+})
+}

--- a/modules/app/find-in-page.js
+++ b/modules/app/find-in-page.js
@@ -1,4 +1,4 @@
-var {remote, shell, clipboard, ipcRenderer, webContents } = require('electron')
+var {remote, shell, clipboard, ipcRenderer } = require('electron')
 var nest = require('depnest')
 var { h, Value, computed, Struct, when } = require('mutant')
 
@@ -29,18 +29,20 @@ exports.create = function (api) {
     const searchString = Value('')
     const resultCount = Value(null)
 
+    window.searchString = searchString
+
     ipcRenderer.on('showSearch', () => shown.set(true))
     views.currentView(() => shown.set(false))
 
-    // webContents.on('found-in-page', (event, result) => {
-    //   resultCount.set(result.matches)
-    //   // if (result.finalUpdate) webContents.stopFindInPage('clearSelection')
-    // })
+    ipcRenderer.on('found-in-page', (event, result) => {
+      resultCount.set(result.matches - 1)
+      console.log('found-in-page',{ event, result })
+    })
 
     searchString(search => {
-      console.log('searching for', search, [views.html])
       if (search.length > 0) {
-        webContents.findInPage(search)
+        console.log('sending', search)
+        ipcRenderer.send('findInPage', search)
       } else {
         resultCount.set(null)
       }


### PR DESCRIPTION
Work in progress for a `find in page` functionality. It doesn't do the actual finding in the page but the interface open, closes, is aware of when the page changes and in general behaves like the chrome find in window.  

The `electron.webContents` is null when I try to use it. I think that's because it only exists in the node context and not in the web context?  I could use the ipc events to send information around but that seems hacky. I think I'm misunderstanding something about the different contexts.

I'm pretty new to *everything* patchwork uses, so any and all feedback is welcome. Mutant and observables are really neat but most of what I have was me guessing and copying from existing usage, as I'm confused to Mutant's relationship to hyperscript (docs don't line up at the very least).

Will eventually close #507 

Reference:
- https://github.com/mmckegg/mutant/blob/master/html-element.js (no docs)
- [findInPage](https://electronjs.org/docs/api/web-contents#contentsfindinpagetext-options)
- [found-in-page](https://electronjs.org/docs/api/web-contents#event-found-in-page)
- [example find in page project](https://github.com/nakajmg/electron-search-text)

Todo:
- [ ] Actual finding in the page
- [ ] styling
