### PR TITLE
Add an "open external link" to the context menu

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -62,7 +62,7 @@ function setupContextMenuAndSpellCheck (config) {
     return menu
   }
 
-  module.exports = new ContextMenuListener((info) => {
+  new ContextMenuListener((info) => {
     contextMenuBuilder.buildMenuForElement(info).then((menu) => {
       var element = document.elementFromPoint(info.x, info.y)
       while (element && !element.msg) {
@@ -107,6 +107,16 @@ function setupContextMenuAndSpellCheck (config) {
             }
           }))
         }
+        menu.append(new MenuItem({
+          label: 'Open External Link',
+          click: function () {
+            const key = element.msg.key
+            const gateway = config.gateway ||
+              'https://viewer.scuttlebot.io'
+            const url = `${gateway}/${encodeURIComponent(key)}`
+            shell.openExternal(url)
+          }
+        }))
         menu.append(new MenuItem({
           label: 'Copy External Link',
           click: function () {


### PR DESCRIPTION
Also cleans up a module.exports assigning that didn't work

I found that 100% of the time I would open the link in my browser to make sure it included everything relevant to the thread but I understand if we don't want to clutter the menus.