### PR TITLE
Change "Learn More" to point to scuttlebutt.nz

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,13 @@ electron.app.on('ready', () => {
       { type: 'separator' },
       { role: 'togglefullscreen' }
     ]
+    var help = menu.find(x => x.label === 'Help')
+    help.submenu = [
+      {
+        label: 'Learn More',
+        click () { require('electron').shell.openExternal('https://scuttlebutt.nz') }
+      }
+    ]
     if (process.platform === 'darwin') {
       var win = menu.find(x => x.label === 'Window')
       win.submenu = [


### PR DESCRIPTION
As per discussion at:
  %w2qoAYcVvEX9z1hhvbra1ypCtRprWV8LclgudQAdn3k=.sha256

This commit changes the default "Learn More" from electron to:
 https://scuttlebutt.nz/

This addresses issue #729 on Github.