### PR TITLE
[wip] Add the option to change the url of the external viewer.

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -5,7 +5,7 @@ var ref = require('ssb-ref')
 
 module.exports = setupContextMenuAndSpellCheck
 
-function setupContextMenuAndSpellCheck (config) {
+function setupContextMenuAndSpellCheck (config, settings) {
   window.spellCheckHandler = new SpellCheckHandler()
   window.spellCheckHandler.attachToInput()
 
@@ -68,6 +68,7 @@ function setupContextMenuAndSpellCheck (config) {
       while (element && !element.msg) {
         element = element.parentNode
       }
+      var viewerUrl = settings.get('patchwork.viewerUrl','https://viewer.scuttlebot.io')
 
       menu.append(new MenuItem({
         label: 'Inspect Server Process',
@@ -112,7 +113,7 @@ function setupContextMenuAndSpellCheck (config) {
           click: function () {
             const key = element.msg.key
             const gateway = config.gateway ||
-              'https://viewer.scuttlebot.io'
+              viewerUrl
             const url = `${gateway}/${encodeURIComponent(key)}`
             clipboard.writeText(url)
           }

--- a/main-window.js
+++ b/main-window.js
@@ -43,10 +43,11 @@ module.exports = function (config) {
     'app.linkPreview': 'first',
     'channel.obs.subscribed': 'first',
     'settings.obs.get': 'first',
+    'settings.sync.get': 'first',
     'intl.sync.i18n': 'first'
   }))
 
-  setupContextMenuAndSpellCheck(api.config.sync.load())
+  setupContextMenuAndSpellCheck(api.config.sync.load(), api.settings.sync)
 
   const i18n = api.intl.sync.i18n
 

--- a/modules/page/html/render/settings.js
+++ b/modules/page/html/render/settings.js
@@ -30,6 +30,7 @@ exports.create = function (api) {
     const filterSubscriptions = api.settings.obs.get('filters.subscriptions')
     const onlySubscribed = api.settings.obs.get('filters.onlySubscribed')
     const filterChannelViewSubscriptions = api.settings.obs.get('filters.channelView.subscriptions')
+    const viewerUrl = api.settings.obs.get('patchwork.viewerUrl', 'https://viewer.scuttlebot.io')
 
     var prepend = [
       h('PageHeading', [
@@ -79,6 +80,15 @@ exports.create = function (api) {
               h('option', {value: ''}, i18n('Default')),
               fontSizes.map(size => h('option', {value: size}, size))
             ])
+          ]),
+
+          h('section', [
+            h('h2', i18n('External Viewer')),
+            h('input.text', {
+              style: { 'width': '250px' },
+              value: viewerUrl,
+              'ev-change': (ev) => viewerUrl.set(ev.target.value)
+            })
           ]),
 
           h('section', [


### PR DESCRIPTION
I think it is convenient to be able to configure this option easily (currently it can be done by editing .ssb/config).
What I did was add an option to the configuration panel and use that url when right clicking on a post.

![captura de pantalla de 2018-03-06 10-49-40](https://user-images.githubusercontent.com/10773838/37035796-6cf326ba-212c-11e8-9d40-a76c2d43c223.png)
