### PR TITLE
add rendering for blog messages

### DIFF
--- a/modules/feed/html/rollup.js
+++ b/modules/feed/html/rollup.js
@@ -244,6 +244,7 @@ exports.create = function (api) {
       var renderedMessage = api.message.html.render(item, {
         compact: compactFilter(item),
         includeForks: false, // this is a root message, so forks are already displayed as replies
+        renderAsCard: true,
         priority: getPriority(item)
       })
 

--- a/modules/feed/html/rollup.js
+++ b/modules/feed/html/rollup.js
@@ -244,7 +244,7 @@ exports.create = function (api) {
       var renderedMessage = api.message.html.render(item, {
         compact: compactFilter(item),
         includeForks: false, // this is a root message, so forks are already displayed as replies
-        renderAsCard: true,
+        inRollup: true,
         priority: getPriority(item)
       })
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pull-ping": "^2.0.2",
     "pull-pushable": "^2.0.1",
     "pull-stream": "~3.6.0",
+    "scuttle-blog": "^1.0.0",
     "scuttlebot": "github:ssbc/scuttlebot#22d894d03235a96f1cad8e836b55ca57eb25d17f",
     "secret-stack": "4.0.1",
     "sorted-array-functions": "~1.0.0",

--- a/plugs/message/html/render/blog.js
+++ b/plugs/message/html/render/blog.js
@@ -7,6 +7,7 @@ exports.gives = nest('message.html.render')
 
 exports.needs = nest({
   'about.obs.color': 'first',
+  'app.navigate': 'first',
   'blob.sync.url': 'first',
   'message.html.decorate': 'reduce',
   'message.html.layout': 'first',
@@ -21,20 +22,17 @@ exports.create = function (api) {
     if (!isBlog(msg)) return
 
     var blog = Blog(api.sbot.obs.connection).obs.get(msg)
-    var showBlog = Value(false)
-    // var showBlog = Value(true)
+    var content = opts.renderAsCard
+      ? BlogCard({
+        blog,
+        onClick: () => api.app.navigate(msg.key),
+        color: api.about.obs.color,
+        blobUrl: api.blob.sync.url
+      })
+      : BlogFull(blog, api.message.html.markdown)
 
     const element = api.message.html.layout(msg, Object.assign({}, {
-      content: when(showBlog,
-        BlogFull(blog, api.message.html.markdown),
-        BlogCard({
-          blog,
-          onClick: () => showBlog.set(true),
-          color: api.about.obs.color,
-          blobUrl: api.blob.sync.url
-        })
-        // Sample(blog, api.blob.sync.url, showBlog)
-      ),
+      content,
       layout: 'default'
     }, opts))
 

--- a/plugs/message/html/render/blog.js
+++ b/plugs/message/html/render/blog.js
@@ -1,0 +1,96 @@
+const nest = require('depnest')
+const Blog = require('scuttle-blog')
+const isBlog = require('scuttle-blog/isBlog')
+const { h, Value, computed, when, resolve } = require('mutant')
+
+exports.gives = nest('message.html.render')
+
+exports.needs = nest({
+  'about.obs.color': 'first',
+  'blob.sync.url': 'first',
+  'message.html.decorate': 'reduce',
+  'message.html.layout': 'first',
+  'message.html.markdown': 'first',
+  'sbot.obs.connection': 'first'
+})
+
+exports.create = function (api) {
+  return nest('message.html.render', blogRenderer)
+
+  function blogRenderer (msg, opts) {
+    if (!isBlog(msg)) return
+
+    var blog = Blog(api.sbot.obs.connection).obs.get(msg)
+    var showBlog = Value(false)
+    // var showBlog = Value(true)
+
+    const element = api.message.html.layout(msg, Object.assign({}, {
+      content: when(showBlog,
+        BlogFull(blog, api.message.html.markdown),
+        BlogCard({
+          blog,
+          onClick: () => showBlog.set(true),
+          color: api.about.obs.color,
+          blobUrl: api.blob.sync.url
+        })
+        // Sample(blog, api.blob.sync.url, showBlog)
+      ),
+      layout: 'default'
+    }, opts))
+
+    return api.message.html.decorate(element, { msg })
+  }
+}
+
+function BlogFull (blog, renderMd) {
+  return computed(blog.body, body => {
+    if (body && body.length) {
+      return h('BlogFull.Markdown', [
+        h('h1', blog.title),
+        renderMd(body)
+      ])
+    }
+
+    return h('BlogFull.Markdown', [
+      h('h1', blog.title),
+      blog.summary,
+      h('p', 'loading...')
+    ])
+  })
+}
+
+function BlogCard ({ blog, blobUrl, onClick, color }) {
+  const thumbnail = when(blog.thumbnail,
+    h('Thumbnail', {
+      style: {
+        'background-image': `url("${blobUrl(resolve(blog.thumbnail))}")`,
+        'background-position': 'center',
+        'background-size': 'cover'
+      }
+    }),
+    h('Thumbnail -empty', {
+      style: { 'background-color': color(blog.title) }
+    }, [
+      h('i.fa.fa-file-text-o')
+    ])
+  )
+
+  var b = h('BlogCard', { 'ev-click': onClick }, [
+    // h('div.context', [
+    //   api.about.html.avatar(author, 'tiny'),
+    //   h('div.name', api.about.obs.name(author)),
+    //   api.message.html.timeago(blog)
+    // ]),
+    h('div.content', [
+      thumbnail,
+      h('div.text.Markdown', [
+        h('h1', blog.title),
+        // when(blog.channel, api.message.html.channel(blog.channel))
+        h('div.summary', blog.summary),
+        h('div.read', 'Read blog')
+      ])
+    ])
+  ])
+
+  return b
+}

--- a/plugs/message/html/render/blog.js
+++ b/plugs/message/html/render/blog.js
@@ -22,7 +22,7 @@ exports.create = function (api) {
     if (!isBlog(msg)) return
 
     var blog = Blog(api.sbot.obs.connection).obs.get(msg)
-    var content = opts.renderAsCard
+    var content = opts.inRollup
       ? BlogCard({
         blog,
         onClick: () => api.app.navigate(msg.key),

--- a/styles/dark/blog-card.mcss
+++ b/styles/dark/blog-card.mcss
@@ -1,0 +1,51 @@
+BlogCard {
+  box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 10px
+  margin: 2rem 0
+
+  display: flex
+  flex-direction: column
+
+  div.content {
+    display: flex
+    flex-direction: row
+    flex-grow: 1
+
+    cursor: pointer
+
+
+    div.Thumbnail {
+      margin-right: 1rem
+    }
+
+    div.text {
+      padding: .5rem
+      div.summary {
+      }
+      div.read {
+        margin-top: 1rem
+        text-decoration: underline
+      }
+    }
+
+  }
+  background-color: rgba(255, 255, 255, 0.08)
+}
+
+Thumbnail {
+  min-width: 20rem 
+  width: 20rem
+  min-height: 10rem
+  /* height: 10rem */
+
+  -empty {
+    color: #fff
+    font-size: 1.8rem
+    opacity: .8
+
+    display: flex
+    justify-content: center
+    align-items: center
+  }
+}
+
+

--- a/styles/light/blog-card.mcss
+++ b/styles/light/blog-card.mcss
@@ -1,0 +1,51 @@
+BlogCard {
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 10px
+  margin: 2rem 0
+
+  display: flex
+  flex-direction: column
+
+  div.content {
+    display: flex
+    flex-direction: row
+    flex-grow: 1
+
+    cursor: pointer
+
+
+    div.Thumbnail {
+      margin-right: 1rem
+    }
+
+    div.text {
+      padding: .5rem
+      div.summary {
+      }
+      div.read {
+        margin-top: 1rem
+        text-decoration: underline
+      }
+    }
+
+  }
+  background-color: #fff
+}
+
+Thumbnail {
+  min-width: 20rem 
+  width: 20rem
+  min-height: 10rem
+  /* height: 10rem */
+
+  -empty {
+    color: #fff
+    font-size: 1.8rem
+    opacity: .8
+
+    display: flex
+    justify-content: center
+    align-items: center
+  }
+}
+
+


### PR DESCRIPTION
**PR-type**: feature (minor version change?)

**what it does**: adds a plug which renders "blog" type messages. By default, the blog is loaded in a 'collapsed' form as a BlogCard. This means the blog doesn't take up as much space, and also gives time for the blob (where the blog content) to be fetched gracefully underneath.
When you click the card it expands the blog into it's full form

## Blog card  (collapsed form)

![selection_568](https://user-images.githubusercontent.com/2665886/38407532-f8de6a9a-39cd-11e8-8745-e4159acbf713.jpg)

:heavy_check_mark:  There's styling for light and dark BlogCards

Here's what it looks like with replies:

![selection_570](https://user-images.githubusercontent.com/2665886/38407530-f8829436-39cd-11e8-81be-add02ee33e8b.jpg)

## Blog (expanded form)

![selection_569](https://user-images.githubusercontent.com/2665886/38407531-f8b0bd2a-39cd-11e8-8a3f-306532ffadfd.jpg)


