### PR TITLE
Close #693 Use full path for electron icon

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ function openMainWindow () {
       title: 'Patchwork',
       show: true,
       backgroundColor: '#EEE',
-      icon: './assets/icon.png'
+      icon: Path.join(__dirname, 'assets/icon.png')
     })
     windowState.manage(windows.main)
     windows.main.setSheetOffset(40)


### PR DESCRIPTION
This closes #693 by referencing where the icon is directly. 

Tested this by building using `electron-builder`'s `build --linux AppImage` and the resulting AppImage has a proper icon. Without these changes it's the default image as described in #693. 

![screenshot from 2018-05-07 10-25-25](https://user-images.githubusercontent.com/485583/39717865-faf1e4a8-51e0-11e8-8f8d-a5346791fb1c.png)

Edit: took me a moment to figure out what the build process was for the AppImage, if there's variables you all use, should this be stored in package.json as described on [the electron-builder site](https://www.electron.build/configuration/configuration)? I'm happy to add the documentation for this. 
