### PR TITLE
Add name publicness note

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -196,5 +196,5 @@
 	"liked": "liked",
 	"(missing message)": "(missing message)",
 	"What would you like to call ": "What would you like to call ",
-	"Nicknames you assign here will be publicly visible to others.": "Nicknames you assign here will be publicly visible to others."
+	"Names you assign here will be publicly visible to others.": "Names you assign here will be publicly visible to others."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -194,5 +194,7 @@
 	"Describe the gathering (if you want)": "Describe the gathering (if you want)",
 	"Create Gathering": "Create Gathering",
 	"liked": "liked",
-	"(missing message)": "(missing message)"
+	"(missing message)": "(missing message)",
+	"What would you like to call ": "What would you like to call ",
+	"Nicknames you assign here will be publicly visible to others.": "Nicknames you assign here will be publicly visible to others."
 }

--- a/modules/page/html/render/profile.js
+++ b/modules/page/html/render/profile.js
@@ -352,11 +352,11 @@ exports.create = function (api) {
               'font-weight': 'normal'
             }
           }, [i18n('What would you like to call '), h('strong', [currentName]), '?']),
-          h('p', {
+          h('h2', {
             style: {
               'font-weight': 'normal'
             }
-          }, [i18n('Nicknames you assign here will be publicly visible to others.')]),
+          }, [i18n('Names you assign here will be publicly visible to others.')]),
           input
         ]),
         footer: [

--- a/modules/page/html/render/profile.js
+++ b/modules/page/html/render/profile.js
@@ -352,6 +352,11 @@ exports.create = function (api) {
               'font-weight': 'normal'
             }
           }, [i18n('What would you like to call '), h('strong', [currentName]), '?']),
+          h('p', {
+            style: {
+              'font-weight': 'normal'
+            }
+          }, [i18n('Nicknames you assign here will be publicly visible to others.')]),
           input
         ]),
         footer: [


### PR DESCRIPTION
I think it's important to have this be explicit.

I tried working on adding a similar note for assigning profile images, but had some trouble figuring out maintaining the styling after putting the file chooser behind a "Confirm" message. I think it'd be good to have one for that, too, though.