### PR TITLE
Preview and publish

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -138,7 +138,6 @@
 	"on ": "auf ",
 	"Private Message": "Private Nachricht",
 	"Send Private Message": "Private Nachricht senden",
-	"Publish Privately": "Privat veröffentlichen",
 	"de": "German",
 	"Public key for this profile": "Öffentlicher Schlüssel für dieses Profil",
 	"This person is blocked by %s of your friends.": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,6 +1,5 @@
 {
 	"Publishing...": "Publishing...",
-	"Publish Privately": "Publish Privately",
 	"Publish": "Publish",
 	"Preview & Publish Privately": "Preview & Publish Privately",
 	"Preview & Publish": "Preview & Publish",

--- a/locales/en.json
+++ b/locales/en.json
@@ -2,6 +2,8 @@
 	"Publishing...": "Publishing...",
 	"Publish Privately": "Publish Privately",
 	"Publish": "Publish",
+	"Preview & Publish Privately": "Preview & Publish Privately",
+	"Preview & Publish": "Preview & Publish",
 	"Welcome to Patchwork": "Welcome to Patchwork",
 	"You may not be able to see new content until you follow some users or pubs.": "You may not be able to see new content until you follow some users or pubs.",
 	"For help, see the 'Getting Started' guide at ": "For help, see the 'Getting Started' guide at ",

--- a/locales/es.json
+++ b/locales/es.json
@@ -136,7 +136,6 @@
 	"en": "en",
 	"es": "es",
 	"ki": "ki",
-	"Publish Privately": "Publicar en privado",
 	"Send Private Message": "Enviar mensaje privado",
 	"de": "de",
 	"pt": "pt",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -1,6 +1,5 @@
 {
 	"Publishing...": "Publikowanie...",
-	"Publish Privately": "Opublikuj Prywatnie",
 	"Publish": "Opublikuj",
 	"Welcome to Patchwork": "Witaj w Patchwork",
 	"You may not be able to see new content until you follow some users or pubs.": "Możesz nie być w stanie zobaczyć nowych postów dopóki nie zaczniesz obserwować jakichś użytkowników albo pubów.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -140,6 +140,5 @@
 	"on ": "on ",
 	"Private Message": "Mensagem Privada",
 	"Send Private Message": "Enviar Mensagem Privada",
-	"Publish Privately": "Publicar Privadamente",
 	"Font Size": "Tamanho da fonte"
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -141,6 +141,5 @@
 	"on ": "em ",
 	"Private Message": "Mensagem Privada",
 	"Send Private Message": "Enviar Mensagem Privada",
-	"Publish Privately": "Publicar Privadamente",
 	"Font Size": "Tamanho da fonte"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -1,6 +1,5 @@
 {
 	"Publishing...": "Публикация...",
-	"Publish Privately": "Публиковать Приватно",
 	"Publish": "Опубликовать",
 	"Welcome to Patchwork": "Добро пожаловать в Patchwork",
 	"You may not be able to see new content until you follow some users or pubs.": "Возможно, вы не сможете увидеть новый контент, пока не будете следовать за некоторыми пользователями или пабами.",

--- a/locales/sl.json
+++ b/locales/sl.json
@@ -1,6 +1,5 @@
 {
 	"Publishing...": "Objavljanje poteka...",
-	"Publish Privately": "Objavi kot zasebno",
 	"Publish": "Objavi",
 	"Welcome to Patchwork": "Dobrodošel_a na Patchwork",
 	"You may not be able to see new content until you follow some users or pubs.": "Verjetno je, da ne boš videl_a nobenih vsebin, dokler ne začneš spremljati uporabnikov ali pubov.",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -1,6 +1,5 @@
 {
 	"Publishing...": "Публікація...",
-	"Publish Privately": "Публікувати Приватно",
 	"Publish": "Опублікувати",
 	"Welcome to Patchwork": "Ласкаво просимо в Patchwork",
 	"You may not be able to see new content until you follow some users or pubs.": "Можливо, ви не зможете побачити новий контент, поки не будете слідкувати за деякими користувачами або пабами.",

--- a/locales/ur.json
+++ b/locales/ur.json
@@ -82,7 +82,6 @@
 	"Filters": "Filters",
 	"Hide following messages": "Hide following messages",
 	"Font Size": "Font Size",
-	"Publish Privately": "Publish Privately",
 	"You may not be able to see new content until you follow some users or pubs.": "You may not be able to see new content until you follow some users or pubs.",
 	"You are not following anyone": "You are not following anyone",
 	"For help getting started, see the guide at ": "For help getting started, see the guide at ",

--- a/modules/message/html/compose.js
+++ b/modules/message/html/compose.js
@@ -111,7 +111,7 @@ exports.create = function (api) {
       disabled: publishing
     }, when(publishing,
       i18n('Publishing...'),
-      when(isPrivate, i18n('Publish Privately'), i18n('Publish'))
+      when(isPrivate, i18n('Preview & Publish Privately'), i18n('Preview & Publish'))
     ))
 
     var actions = h('section.actions', [


### PR DESCRIPTION
To address #810

I think this tiny change will clear up a lot... it took a couple mistakes for me to realize that profile publishes and gathering publishes don't get previewed, but public/private posts do. This should make that more explicit.

If anyone knows any of the supported locales and wants to update those files that would be great. I only know English so that's what we've got here.