### PR TITLE
Add preview text for profile changes

### DIFF
--- a/modules/profile/sheet/edit.js
+++ b/modules/profile/sheet/edit.js
@@ -83,7 +83,7 @@ exports.create = function (api) {
           h('button -save', {
             'ev-click': save,
             'disabled': publishing
-          }, when(publishing, i18n('Publishing...'), i18n('Publish'))),
+          }, when(publishing, i18n('Publishing...'), i18n('Preview & Publish'))),
           h('button -cancel', {
             'disabled': publishing,
             'ev-click': close


### PR DESCRIPTION
Sorry-- one more small PR for #810... didn't realize until now that @mmckegg had added preview support for profile changes, so this adds the new button text to the profile edit composer to keep things clear and consistent. 