### PR TITLE
Fix crash when publishing no text

### DIFF
--- a/modules/message/html/compose.js
+++ b/modules/message/html/compose.js
@@ -166,6 +166,9 @@ exports.create = function (api) {
     // scoped
 
     function publish () {
+      if (!textArea.value) {
+        return
+      }
       publishing.set(true)
 
       var content = extend(resolve(meta), {


### PR DESCRIPTION
Fixes #801 

Just returns early from the publish function, and the UX is smooth:

![empty-message](https://user-images.githubusercontent.com/2707340/41476487-acd5c7f8-708f-11e8-9db2-589565e87ac8.gif)
