### PR TITLE
Add appdata and desktop files

### DIFF
--- a/assets/nz.scuttlebutt.Patchwork.appdata.xml
+++ b/assets/nz.scuttlebutt.Patchwork.appdata.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>nz.scuttlebutt.Patchwork</id>
+  <name>Patchwork</name>
+  <project_license>AGPL-3.0</project_license>
+  <developer_name>Secure Scuttlebutt Consortium</developer_name>
+  <summary>A decentralized messaging and sharing app</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://www.scuttlebutt.nz/</url>
+  <url type="bugtracker">https://github.com/ssbc/patchwork/issues</url>
+  <launchable type="desktop-id">nz.scuttlebutt.Patchwork.desktop</launchable>
+  <description>
+    <p>
+      A decentralized messaging and sharing app built on top of Secure
+      Scuttlebutt (SSB).
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://raw.githubusercontent.com/ssbc/patchwork/master/screenshot.jpg</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Network</category>
+    <category>Chat</category>
+    <category>Feed</category>
+  </categories>
+  <icon type="remote" height="512" width="512">
+    https://raw.githubusercontent.com/ssbc/patchwork/master/assets/icon.png
+  </icon>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</component>

--- a/assets/nz.scuttlebutt.Patchwork.desktop
+++ b/assets/nz.scuttlebutt.Patchwork.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Patchwork
+Icon=nz.scuttlebutt.Patchwork
+Exec=npm start
+Categories=Network;Chat;Feed;


### PR DESCRIPTION
Hi, I'm trying to package Patchwork for distribution on Flathub (https://flathub.org) and I thought you might like to have these metadata files as they could be useful for the AppImage build as well. These files are used for providing metadata (descriptions, icons,...) for various app stores on Linux.