### PR TITLE
Bring NPM dependencies up-to-date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.20.tgz",
-      "integrity": "sha512-M7x8+5D1k/CuA6jhiwuSCmE8sbUWJF0wYsjcig9WrXvwUI5ArEoUBdOXpV4JcEMrLp02/QbDjw+kI+vQeKyQgg==",
+      "version": "8.10.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.21.tgz",
+      "integrity": "sha512-87XkD9qDXm8fIax+5y7drx84cXsu34ZZqfB7Cial3Q/2lxSoJ/+DRaWckkCbxP41wFSIrrb939VhzaNxj4eY1w==",
       "dev": true
     },
     "abbrev": {
@@ -173,9 +173,9 @@
       }
     },
     "app-root-path": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
-      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
+      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
     },
     "append-batch": {
       "version": "0.0.1",
@@ -1408,9 +1408,9 @@
       "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "electron": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.3.tgz",
-      "integrity": "sha512-SLCmnEqcpZD+GjNWcqRvr+CC8palbN6O/wlCcGJgUtPkQqwGiUg9V3FK4/0HnWdp0YQpmQrZh9BzqtW3Hiw96w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-2.0.4.tgz",
+      "integrity": "sha512-rtg6aW2IpWfiwMRk9gqr+a/xOrFlch9sgLNg0UJzCmtUUEGTrbaLxqANr3Ahlx+ODmh/V+WfF7IdEpD76bbssA==",
       "dev": true,
       "requires": {
         "@types/node": "^8.0.24",
@@ -2167,9 +2167,9 @@
       }
     },
     "flatpickr": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.0.tgz",
-      "integrity": "sha512-7AfaM2BVyQmFW4uBpzgoNeRUr6EZlvEh4Pnj298rEsHBq8LIZnPgRaesLORir7dATETUvoLkhrfXZdmNssma+A=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.5.1.tgz",
+      "integrity": "sha512-dsLTFmRg6mlqYfJ35A7gLlbq+8fOqRty3cWncl6rwU4pMe//i0WKxKLVyBbSYAZry93Lg+yqsOph9haltcxCqQ=="
     },
     "flumecodec": {
       "version": "0.0.0",
@@ -2232,9 +2232,9 @@
       }
     },
     "flumeview-hashtable": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.3.tgz",
-      "integrity": "sha1-0qn6Fkn1fvaNG4nrTEO/sXJDeWc=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/flumeview-hashtable/-/flumeview-hashtable-1.0.4.tgz",
+      "integrity": "sha512-4L52hBelX7dYVAQQ9uPjksqxOCxLwI4NsfEG/+sTM423axT2Poq5cnfdvGm3HzmNowzwDIKtdy429r6PbfKEIw==",
       "requires": {
         "async-single": "^1.0.5",
         "atomic-file": "^1.1.3",
@@ -3929,9 +3929,9 @@
       }
     },
     "level-sublevel": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
-      "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
+      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
       "requires": {
         "bytewise": "~1.1.0",
         "levelup": "~0.19.0",
@@ -4502,9 +4502,9 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.20.tgz",
-      "integrity": "sha512-uJXgstE4ddmJpLFIyihm7VsLJsViDxO88lx+GmIbSnyAAHHbSdpwBhpE2N3KFOmDa/9BxYDykQUzH796CHga2w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -5066,7 +5066,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
     },
     "opencollective-postinstall": {
@@ -6478,9 +6478,9 @@
       }
     },
     "secure-scuttlebutt": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.1.0.tgz",
-      "integrity": "sha512-Hadgtl3A+eKFOvhrnXoLJBQZXnCiCsbghqYSYZYxuysFAHqFRpqJ0m9VElJUVtjsoUYczOz7zXCVq8K65ovPdg==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/secure-scuttlebutt/-/secure-scuttlebutt-18.1.1.tgz",
+      "integrity": "sha512-mK0Wims55gi6blMLCb2vKZui+K5AgJMxGiGD7pnXIkUt6URn7SSShC7FNaL+w/Vnmld+No9iyIonZGJlytqKqA==",
       "requires": {
         "async-write": "^2.1.0",
         "cont": "~1.0.0",
@@ -6912,9 +6912,9 @@
       }
     },
     "ssb-ebt": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.0.tgz",
-      "integrity": "sha512-u7n5O2YRyF6SvX4RMxf7I1Mm6r95pmSKshx1CbmnOpa05PFzzFvi3vjiQnse1TEpWYcVpYn2zwugOVflZxZlhw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ssb-ebt/-/ssb-ebt-5.2.1.tgz",
+      "integrity": "sha512-Tcxqng+k5w5v7OSG4AYxShqGGMDhAsRqDMBoVO/6H6RYTgBxRqh/oVF6uK/VLB5yn0+V66+cSBreaq4mcYytDg==",
       "requires": {
         "base64-url": "^1.3.3",
         "epidemic-broadcast-trees": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Secure Scuttlebutt Consortium",
   "license": "AGPL-3.0",
   "dependencies": {
-    "app-root-path": "^2.0.1",
+    "app-root-path": "^2.1.0",
     "bulk-require": "^1.0.1",
     "compare-version": "^0.1.2",
     "cross-script": "^1.0.5",
@@ -29,7 +29,7 @@
     "emojilib": "^2.2.12",
     "escape-string-regexp": "^1.0.5",
     "fix-path": "^2.1.0",
-    "flatpickr": "^4.4.6",
+    "flatpickr": "^4.5.1",
     "flumeview-level": "^3.0.4",
     "flumeview-reduce": "^1.3.13",
     "flumeview-search": "^1.0.3",
@@ -40,7 +40,7 @@
     "lrucache": "^1.0.3",
     "micro-css": "^2.0.1",
     "moment": "^2.22.1",
-    "moment-timezone": "^0.5.17",
+    "moment-timezone": "^0.5.21",
     "mutant": "^3.22.1",
     "mutant-pull-reduce": "^1.1.0",
     "obv": "0.0.1",
@@ -86,7 +86,7 @@
   },
   "devDependencies": {
     "colors": "^1.2.5",
-    "electron": "^2.0.0",
+    "electron": "^2.0.4",
     "node-gyp": "^3.6.2"
   }
 }


### PR DESCRIPTION
I'd imagine doing this every so often is probably going to be much less painful than trying to do heaps of them when some downstream dependency breaks.

- patchcore       (1.27.2 -> 1.28.0)
- ssb-backlinks   (0.7.1 -> 0.7.2)
- ssb-search      (1.1.1 -> 1.1.2)
- app-root-path   (2.0.1 -> 2.1.0)
- electron        (2.0.3 -> 2.0.4)
- flatpickr       (4.5.0 -> 4.5.1)
- moment-timezone (0.5.20 -> 0.5.21)

Please let me know if you'd prefer me to work on this another way -- I usually run the edge of `master` so it's easy for me to progressively update our dependencies and make sure everything keeps chugging along.