### PR TITLE
fix isParticipant to handle the case where recps includes a feed mention

### DIFF
--- a/modules/page/html/render/message.js
+++ b/modules/page/html/render/message.js
@@ -49,7 +49,14 @@ exports.create = function (api) {
     var isRecipient = computed(meta.recps, recps => {
       if (recps == null) return true // not a private message
       return Array.isArray(recps) && recps.some(recp => {
-        return recp === api.keys.sync.id()
+        if (recp == null) return false
+        if (typeof recp === 'string') {
+          return recp === api.keys.sync.id()
+        }
+        // if recp is mentions object
+        if (typeof recp === 'object') {
+          return recp.link === api.keys.sync.id()
+        }
       })
     })
 


### PR DESCRIPTION
with the previous private link change, i disabled the compose when you aren't a participant.

i didn't realize `recps` could include a feed mention, this fixes that. :sweat_smile: 