### PR TITLE
Ensure that msg.value is truthy

### DIFF
--- a/sbot/channel-feed.js
+++ b/sbot/channel-feed.js
@@ -116,6 +116,7 @@ exports.init = function (ssb, config) {
 }
 
 function checkBump (msg, { channel }) {
+  if (!msg.value) return
   if (msg.value.content.type === 'vote') return
   if (normalizeChannel(msg.value.content.channel) === channel) {
     if (getRoot(msg)) {


### PR DESCRIPTION
Resolves #882 

---

This resolves and edge-case where a message is being passed to checkBump. I'm unclear on *why* this is necessary, as sbot seems to be reporting that the message doesn't exist, but it should resolve the bug.

cc: @smowafy could you test this and let me know if it resolves the issue?