### PR TITLE
Fix inaccurate slovak localization

### DIFF
--- a/locales/sk.json
+++ b/locales/sk.json
@@ -108,7 +108,7 @@
 		"one": "%s človek z tvojej siete odpovedal na správu ",
 		"other": "%s ľudia z tvojej siete odpovedali na správu "
 	},
-	"mentioned in your network": "označil ťa v sieti",
+	"mentioned in your network": "spomenuté v tvojej sieti",
 	"Channels": "Kanály",
 	"Browse All": "Browse All",
 	"$name": "Slovensky",


### PR DESCRIPTION
The original localization string "označil ťa v sieti" means "mentions **you** in your network" which doesn't make sense when rendered in Patchwork.