### PR TITLE
Update har-validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3767,9 +3767,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",


### PR DESCRIPTION
I was unable to clone & npm install following a reformat. Turns out har-validator was reset back to 5.1.2 in package-lock, which has been unpublished. To reproduce this issue, git reset && rm node_modules && npm install.

This is a repeat of #898, to fix a reversion introduced in b947e38.

Can we make sure all developers reset their package-lock files and re-install NPM modules, to prevent another reversion from happening? Or better yet, enable branch protection and require PRs for all commits to master.

---
har-validator@5.1.2 was unpublished, so this commit manually updates it
to 5.1.3 to resolve an installation issue with the missing dependency.