### PR TITLE
check contact id validity before passing on

### DIFF
--- a/modules/contact/obs.js
+++ b/modules/contact/obs.js
@@ -3,6 +3,7 @@
 var nest = require('depnest')
 var { computed } = require('mutant')
 var MutantPullDict = require('../../lib/mutant-pull-dict')
+var ref = require('ssb-ref')
 
 exports.needs = nest({
   'sbot.pull.stream': 'first'
@@ -70,7 +71,7 @@ exports.create = function (api) {
   function matchingValueKeys (state, value) {
     var obs = computed(state, state => {
       return Object.keys(state).filter(key => {
-        return state[key] === value
+        return state[key] === value && ref.isLink(key)
       })
     })
 


### PR DESCRIPTION
non-breaking bug fix

ids are pulled from about message content, any invalid follows/follwers/blocks in a sheets.profiles collection throws an error and stops the whole list from displaying. Message content is not guaranteed to be well-formed like feeds themselves are, hence this fix for protection against future errors.

gatherings attendees are similarly pulled from message content, but get checked against the author id in modules/message/html/render/attending.js

> Error: About requires an ssb ref!
>     at socialValue (WORK_DIR/patchwork/modules/about/obs.js:72:32)
>     at Object.imageUrl (WORK_DIR/patchwork/modules/about/obs.js:44:34)
>     at Object.imageUrl (WORK_DIR/patchwork/node_modules/depject/apply.js:18:30)
>     at Object.<anonymous> (WORK_DIR/patchwork/modules/about/html/image.js:16:26)
>     at Object.image (WORK_DIR/patchwork/node_modules/depject/apply.js:18:30)
>     at map (WORK_DIR/patchwork/modules/sheet/profiles.js:96:45)
>     at updateItem (WORK_DIR/patchwork/node_modules/mutant/map.js:227:24)
>     at Immediate.flushQueue [as _onImmediate] (WORK_DIR/patchwork/node_modules/mutant/map.js:150:7)
>     at runCallback (timers.js:789:20)
>     at tryOnImmediate (timers.js:751:5)