### PR TITLE
add key shortcut for submitting from compose

### DIFF
--- a/modules/message/html/compose.js
+++ b/modules/message/html/compose.js
@@ -59,6 +59,12 @@ exports.create = function (api) {
         if (!files || !files.length) return
         attachFiles(files)
       },
+      'ev-keydown': ev => {
+        if (ev.key === 'Enter' && (ev.ctrlKey || ev.metaKey)) {
+          publish()
+          ev.preventDefault()
+        }
+      },
       disabled: publishing,
       placeholder
     })


### PR DESCRIPTION
A quick start, does not yet change anything about the confirmation dialog. That could always be in another PR.

Would it be of interest to have both `ctrl` and `shift` enabled? Something easy enough as:
```javascript
if (ev.keyCode === 13 && (ev.shiftKey || ev.ctrlKey)) {
..
}
```

Will close #813