### PR TITLE
Add SSB URI support

### DIFF
--- a/lib/catch-links.js
+++ b/lib/catch-links.js
@@ -1,5 +1,3 @@
-var Url = require('url')
-
 module.exports = function (root, cb) {
   root.addEventListener('click', (ev) => {
     if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey || ev.defaultPrevented) {
@@ -18,8 +16,16 @@ module.exports = function (root, cb) {
     var href = anchor.getAttribute('href')
 
     if (href) {
-      var url = Url.parse(href)
-      if (url.host) {
+      var isUrl
+
+      try {
+        var url = new URL(href)
+        isUrl = true
+      } catch (e) {
+        isUrl = false
+      }
+
+      if (isUrl && url.host) {
         cb(href, true)
       } else if (href !== '#') {
         cb(href, false, anchor.anchor)

--- a/lib/scroller.js
+++ b/lib/scroller.js
@@ -1,6 +1,6 @@
 var pull = require('pull-stream')
 var Pause = require('pull-pause')
-var { h, onceIdle, computed, Value } = require('mutant')
+var { h, computed, Value } = require('mutant')
 
 window.stopIt = false
 

--- a/main-window.js
+++ b/main-window.js
@@ -13,6 +13,7 @@ var ref = require('ssb-ref')
 var setupContextMenuAndSpellCheck = require('./lib/context-menu-and-spellcheck')
 var watch = require('mutant/watch')
 var requireStyle = require('require-style')
+var ssbUri = require('ssb-uri')
 
 module.exports = function (config) {
   var sockets = combine(
@@ -272,6 +273,15 @@ module.exports = function (config) {
       if (!err && handler) {
         handler(href)
       } else {
+        if (href.startsWith('ssb:')) {
+          try {
+            href = ssbUri.toSigilLink(href)
+          } catch (e) {
+            // error can be safely ignored
+            // it just means this isn't an SSB URI
+          }
+        }
+
         // no external handler found, use page.html.render
         previewElement.cancel()
         views.setView(href, anchor)

--- a/modules/app/html/search.js
+++ b/modules/app/html/search.js
@@ -49,7 +49,6 @@ exports.create = function (api) {
     return searchBox
 
     function doSearch () {
-
       const prefixes = ['/', '?', '@', '#', '%', 'ssb:']
       var value = searchBox.value.trim()
       if (prefixes.some(p => prefixes.includes(p))) {

--- a/modules/app/html/search.js
+++ b/modules/app/html/search.js
@@ -1,6 +1,7 @@
 var h = require('mutant/h')
 var nest = require('depnest')
 var addSuggest = require('suggest-box')
+var ssbUri = require('ssb-uri')
 
 exports.needs = nest({
   'profile.async.suggest': 'first',
@@ -48,10 +49,18 @@ exports.create = function (api) {
     return searchBox
 
     function doSearch () {
+
+      const prefixes = ['/', '?', '@', '#', '%', 'ssb:']
       var value = searchBox.value.trim()
-      if (value.startsWith('/') || value.startsWith('?') || value.startsWith('@') || value.startsWith('#') || value.startsWith('%') || value.startsWith('&')) {
+      if (prefixes.some(p => prefixes.includes(p))) {
         if (value.startsWith('@') && value.length < 30) {
           // probably not a key
+        } else if (value.startsWith('ssb:')) {
+          try {
+            setView(ssbUri.toSigilLink(value))
+          } catch (e) {
+            // not a URI
+          }
         } else if (value.length > 2) {
           setView(value)
         }

--- a/modules/invite/dhtAcceptSheet.js
+++ b/modules/invite/dhtAcceptSheet.js
@@ -1,4 +1,4 @@
-var { h, when, Value, Proxy } = require('mutant')
+var { h, when, Value } = require('mutant')
 var nest = require('depnest')
 var electron = require('electron')
 

--- a/modules/invite/dhtCreateSheet.js
+++ b/modules/invite/dhtCreateSheet.js
@@ -46,7 +46,7 @@ exports.create = function (api) {
               'ev-click': () => {
                 api.sbot.async.createDHT((err, code) => {
                   if (err) {
-                    created.set(false)
+                    creating.set(false)
                     showDialog({
                       type: 'error',
                       title: i18n('Error'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha1-7739PokNsq2dY8dy0WImZf4GV0M="
     },
     "@paulcbetts/cld": {
-      "version": "github:ssbc/paulcbetts-cld-prebuilt#450a647a9267fbdb40a9e7bbb54ccfe0c9a1c4f1",
+      "version": "github:ssbc/paulcbetts-cld-prebuilt#63609a21577c9c44229f16c0f42cf13322035718",
       "from": "github:ssbc/paulcbetts-cld-prebuilt",
       "requires": {
         "glob": "^5.0.10",
@@ -35,7 +35,7 @@
       }
     },
     "@paulcbetts/spellchecker": {
-      "version": "github:ssbc/paulcbetts-spellchecker-prebuilt#32674ecc85fe6470ce899a932bb72206748bb36f",
+      "version": "github:ssbc/paulcbetts-spellchecker-prebuilt#8e28e43d81073b354e7811792b9a39132db52221",
       "from": "github:ssbc/paulcbetts-spellchecker-prebuilt",
       "requires": {
         "nan": "^2.0.0",
@@ -1918,12 +1918,12 @@
       "version": "github:ssbc/electron-spellchecker-prebuilt#7cf59a025481767ac2235fd6c8f6fd548e53db6f",
       "from": "github:ssbc/electron-spellchecker-prebuilt",
       "requires": {
-        "@paulcbetts/cld": "github:ssbc/paulcbetts-cld-prebuilt#450a647a9267fbdb40a9e7bbb54ccfe0c9a1c4f1",
-        "@paulcbetts/spellchecker": "github:ssbc/paulcbetts-spellchecker-prebuilt#32674ecc85fe6470ce899a932bb72206748bb36f",
+        "@paulcbetts/cld": "github:ssbc/paulcbetts-cld-prebuilt#63609a21577c9c44229f16c0f42cf13322035718",
+        "@paulcbetts/spellchecker": "github:ssbc/paulcbetts-spellchecker-prebuilt#8e28e43d81073b354e7811792b9a39132db52221",
         "bcp47": "^1.1.2",
         "debug": "^2.6.3",
         "electron-remote": "^1.1.1",
-        "keyboard-layout": "github:ssbc/keyboard-layout#a361e68c0e18793d534bd168058d8dab43c356f5",
+        "keyboard-layout": "github:ssbc/keyboard-layout#328d41c279a0c1ab07eecba514fcca129b7e40a6",
         "lru-cache": "^4.0.2",
         "mkdirp": "^0.5.1",
         "pify": "^2.3.0",
@@ -4650,7 +4650,7 @@
       }
     },
     "keyboard-layout": {
-      "version": "github:ssbc/keyboard-layout#a361e68c0e18793d534bd168058d8dab43c356f5",
+      "version": "github:ssbc/keyboard-layout#328d41c279a0c1ab07eecba514fcca129b7e40a6",
       "from": "github:ssbc/keyboard-layout",
       "requires": {
         "event-kit": "^2.0.0",
@@ -5572,6 +5572,15 @@
         "pull-stream": "^3.5.0"
       },
       "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
         "pull-pause": {
           "version": "0.0.0",
           "resolved": "https://registry.npmjs.org/pull-pause/-/pull-pause-0.0.0.tgz",
@@ -5994,6 +6003,24 @@
       "resolved": "https://registry.npmjs.org/obv/-/obv-0.0.1.tgz",
       "integrity": "sha1-yyNhBjQVNvDaxIFeBnCCIcrX+14="
     },
+    "ohm-js": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-0.14.0.tgz",
+      "integrity": "sha512-Iuiapfkaf0ZdvuJo9thtE57BT93uNOSIb3/DtwuBNBJiiT28ALzTg++w3HoAXWbQBYPem9Bd8BaNJcDYoABWUA==",
+      "requires": {
+        "es6-symbol": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-buffer": "^1.1.4",
+        "util-extend": "^1.0.3"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
+      }
+    },
     "on-change-network": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz",
@@ -6164,6 +6191,17 @@
         "lodash.mergewith": "^4.6.1",
         "lodash.set": "^4.3.2",
         "mutant": "^3.21.2"
+      },
+      "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "path-exists": {
@@ -7843,6 +7881,15 @@
         "ssb-ref": "^2.9.1"
       },
       "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
         "ssb-about": {
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/ssb-about/-/ssb-about-0.1.2.tgz",
@@ -7862,6 +7909,17 @@
         "libnested": "^1.3.2",
         "mutant": "^3.22.1",
         "pull-defer": "^0.2.2"
+      },
+      "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "scuttle-tag": {
@@ -7880,6 +7938,17 @@
         "ssb-msg-content": "^1.0.1",
         "ssb-ref": "^2.9.1",
         "ssb-sort": "^1.1.0"
+      },
+      "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "secret-handshake": {
@@ -8642,6 +8711,26 @@
             "xtend": "^4.0.1"
           }
         },
+        "flumedb": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/flumedb/-/flumedb-1.0.1.tgz",
+          "integrity": "sha512-mT0v0dY9EkWRGwDtTfavYNv2Z6nrMNlVZCNJD7qxjfPJymfv8kNYB4UvDdBHleHegvzjufjnE73IkRG5DgMjww==",
+          "requires": {
+            "cont": "^1.0.3",
+            "explain-error": "^1.0.3",
+            "obv": "0.0.1",
+            "pull-cont": "0.0.0",
+            "pull-looper": "^1.0.0",
+            "pull-stream": "^3.5.0"
+          },
+          "dependencies": {
+            "pull-cont": {
+              "version": "0.0.0",
+              "resolved": "https://registry.npmjs.org/pull-cont/-/pull-cont-0.0.0.tgz",
+              "integrity": "sha1-P6xIuBrJe3W6ATMgiLDOevjBvg4="
+            }
+          }
+        },
         "level": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/level/-/level-4.0.0.tgz",
@@ -9098,6 +9187,15 @@
         "ssb-ref": "^2.7.1"
       },
       "dependencies": {
+        "mutant": {
+          "version": "3.22.1",
+          "resolved": "https://registry.npmjs.org/mutant/-/mutant-3.22.1.tgz",
+          "integrity": "sha1-kEh1RvcAs8KKqApD0c99M48wdYE=",
+          "requires": {
+            "browser-split": "0.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
         "scuttle-tag": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/scuttle-tag/-/scuttle-tag-0.3.0.tgz",
@@ -9115,6 +9213,14 @@
             "ssb-sort": "^1.1.0"
           }
         }
+      }
+    },
+    "ssb-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ssb-uri/-/ssb-uri-1.0.1.tgz",
+      "integrity": "sha512-WtjMIxiZP9FWf8W/v/mUXKiHbcwIzFX8tqXx/pyUK95he3+F7yEPJk2/nh/DbU6N9/zIoC9yWOq9BfjsfpNv4Q==",
+      "requires": {
+        "ohm-js": "^0.14.0"
       }
     },
     "ssb-validate": {
@@ -9978,6 +10084,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
     },
     "utp-native": {
       "version": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "ssb-server": "^13.3.0",
     "ssb-sort": "^1.1.0",
     "ssb-tags": "^0.2.0",
+    "ssb-uri": "^1.0.1",
     "ssb-ws": "~3.0.2",
     "standard": "^12.0.1",
     "suggest-box": "github:mmckegg/suggest-box#scroll-selection-into-view",


### PR DESCRIPTION
This adds support for the `ssb:` URI scheme in the search box as well as
message links via `navigate()`. The legacy URI parser (`require('url')`)
was also replaced with the WHATWG parser that ships with JavaScript,
which has accurate support for URIs that don't have hostnames.

---

See also: https://github.com/ssbc/patchbay/pull/306