### PR TITLE
Redact private key from startup output

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,9 @@ function setupContext (appName, opts, cb) {
     ssbConfig.remote = `unix:${socketPath}:~noauth:${pubkey}`
   }
 
-  console.log(ssbConfig)
+  const redactedConfig = Object.assign({}, ssbConfig);
+  redactedConfig.keys.private = null
+  console.log(redactedConfig)
 
   if (opts.server === false) {
     cb && cb()

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ function setupContext (appName, opts, cb) {
     ssbConfig.remote = `unix:${socketPath}:~noauth:${pubkey}`
   }
 
-  const redactedConfig = Object.assign({}, ssbConfig);
+  const redactedConfig = JSON.parse(JSON.stringify(ssbConfig))
   redactedConfig.keys.private = null
   console.log(redactedConfig)
 


### PR DESCRIPTION
Previously we did this output *before* adding the keys to the config,
but recently there were changes made that required the keys to be added
to the config before the config was finished. This meant that the config
being output contained private keys, which seems like a major security
hazard for debugging.

This commit changes the code so that we make a copy of the full config,
set `redactedConfig.keys.private = null`, and then output the redacted
configuration safely without any secrets exposed.

---

Resolves #933 