### PR TITLE
Add a confirmation of clearing your draft.

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -300,5 +300,6 @@
 	"You have chosen to privately ignore this person.": "You have chosen to privately ignore this person.",
 	"No new messages will be downloaded. Existing messages will be hidden.": "No new messages will be downloaded. Existing messages will be hidden.",
 	"You have chosen to publicly block this person.": "You have chosen to publicly block this person.",
-	"Click for options to block syncing with this person and/or hide their posts": "Click for options to block syncing with this person and/or hide their posts"
+        "Click for options to block syncing with this person and/or hide their posts": "Click for options to block syncing with this person and/or hide their posts",
+        "Are you certain you want to clear your draft?": "Are you certain you want to clear your draft?"
 }

--- a/modules/message/html/compose.js
+++ b/modules/message/html/compose.js
@@ -144,6 +144,9 @@ exports.create = function (api) {
     // scoped
 
     function clear () {
+      if (!confirm(i18n("Are you certain you want to clear your draft?"))) {
+        return
+      }
       textArea.value = ''
       hasContent.set(!!textArea.value)
       save()


### PR DESCRIPTION
In %A5ZhmozMn/tTVxOunSs5e7nKuGekQ5zGW/oeN+FvpF8=.sha256 , Christian suggested adding this feature, so here it is. This adds a dialog box when a user attempts to clear a draft. Screenshot attached.

I wasn't sure how to handle translations. It would be generally nice if there was a file in the locales folder with some helpful hints.

![screenshot from 2019-02-12 19-01-25](https://user-images.githubusercontent.com/3853/52683864-1d9be080-2ef9-11e9-80e9-a9f8f920777c.png)
