### PR TITLE
Add Ctrl/Cmd+L shortcut to go to search field.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,8 +57,15 @@ electron.app.on('ready', () => {
     var menu = defaultMenu(electron.app, electron.shell)
 
     menu.splice(4, 0, {
-      label: 'History',
+      label: 'Navigation',
       submenu: [
+        {
+          label: 'Activate Search Field',
+          accelerator: 'CmdOrCtrl+L',
+          click: () => {
+            browserWindow.webContents.send('activateSearch')
+          }
+        },
         {
           label: 'Back',
           accelerator: 'CmdOrCtrl+[',

--- a/modules/app/html/search.js
+++ b/modules/app/html/search.js
@@ -33,6 +33,10 @@ exports.create = function (api) {
         }
       }
     })
+    electron.ipcRenderer.on('activateSearch', () => {
+      searchBox.focus()
+      searchBox.select() // should handle selecting everything in the box
+    })
 
     setImmediate(() => {
       addSuggest(searchBox, (inputText, cb) => {


### PR DESCRIPTION
I found myself hitting Ctrl+L quite often, since that's how all the browsers activate the URL bar.
I just looked at how #802 dealt with the Forward/Backward, and tried to adapt. If I understood correctly, the problem here was that I wanted the rendering process to change something in the DOM (i.e. give focus to the input) but was trying to set that up in the main process.

This is of course just an idea. Specifically, passing code as a string strikes me as smelly, but given that I speak close to zero JS, that's what I ended up with. So feel free to ignore this. :P
