### PR TITLE
fix private blob URLs

### DIFF
--- a/modules/blob/sync/url.js
+++ b/modules/blob/sync/url.js
@@ -11,13 +11,22 @@ exports.create = function (api) {
   return nest('blob.sync.url', function (link) {
     var config = api.config.sync.load()
     var prefix = config.blobsPrefix != null ? config.blobsPrefix : `http://localhost:${config.ws.port}/blobs/get`
-    if (link && typeof link.link === 'string') {
-      link = link.link
+
+    if (typeof link !== 'object') {
+      link = ref.parseLink(link)
     }
 
-    var parsed = ref.parseLink(link)
-    if (parsed && ref.isBlob(parsed.link)) {
-      return `${prefix}/${parsed.link}`
-    }
+    return linkToUrl(prefix, link)
   })
+}
+
+function linkToUrl (prefix, link) {
+  if (link == null || !ref.isBlob(link.link)) return null
+  var url = `${prefix}/${link.link}`
+  if (typeof link.query === 'object') {
+    url += '?' + Object.keys(link.query)
+      .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(link.query[key])}`)
+      .join('&')
+  }
+  return url
 }


### PR DESCRIPTION
:smiley_cat:

private blob URLs were missing the unbox key, so the downloaded file was
encrypted gobbledygook. this change ensures the query string (with the
unbox key) is included in the URL.

---

i'm not sure if how i implemented this change is the best way, as in i'm
not sure if this solves one use case only to break another.