### PR TITLE
replace gossip plugin with new rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,36 +42,6 @@
         "prebuild-install": "^2.4.1"
       }
     },
-    "@staltz/sbot-gossip": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@staltz/sbot-gossip/-/sbot-gossip-1.1.6.tgz",
-      "integrity": "sha512-/WTNtBHfXwGB+v61ukIh6xB+Su9/jY+a2dTwRrDSU9BOcdFfpgA2cjrFR73hEXMxDGz6SDaHOb2njKkfy3b0Eg==",
-      "requires": {
-        "atomic-file": "0.0.1",
-        "deep-equal": "^1.0.1",
-        "ip": "^0.3.3",
-        "mdmanifest": "^1.0.4",
-        "on-change-network": "0.0.2",
-        "on-wakeup": "^1.0.0",
-        "pull-notify": "0.1.1",
-        "pull-ping": "^2.0.2",
-        "pull-stream": "^3.6.9",
-        "ssb-ref": "^2.9.1",
-        "statistics": "^3.0.0"
-      },
-      "dependencies": {
-        "atomic-file": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-0.0.1.tgz",
-          "integrity": "sha1-bDZlj2xOzjP7o4d3MefCX8gpmbs="
-        },
-        "ip": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-0.3.3.tgz",
-          "integrity": "sha1-jugwnpLwsEDSh/cu+soaIXAtP7Q="
-        }
-      }
-    },
     "@types/node": {
       "version": "8.10.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
@@ -8662,6 +8632,16 @@
         "rc": "^1.1.6"
       }
     },
+    "ssb-conn-db": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.0.5.tgz",
+      "integrity": "sha512-kmhwtbtBbWC5njDBaHRWwFgjcfxsf9UKuTO24H3NtJ6MLjaR2RGzcSKIT0rddgQqAQ0IUEe/4LQwBF0eiHq0/Q==",
+      "requires": {
+        "atomic-file": "^1.1.5",
+        "multiserver-address": "~1.0.1",
+        "pull-notify": "~0.1.1"
+      }
+    },
     "ssb-db": {
       "version": "18.6.2",
       "resolved": "https://registry.npmjs.org/ssb-db/-/ssb-db-18.6.2.tgz",
@@ -8915,6 +8895,57 @@
         "chloride": "^2.2.8",
         "mkdirp": "~0.5.0",
         "private-box": "^0.3.0"
+      }
+    },
+    "ssb-legacy-conn": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/ssb-legacy-conn/-/ssb-legacy-conn-1.0.12.tgz",
+      "integrity": "sha512-VUx5RN7+w3n1hD3QVBG3WZEqAoTT3zPYwsWKiApCzUeZ871oydJzRBf/iDPhkLXYVUBiaZF99JoevX5M9poI3g==",
+      "requires": {
+        "has-network": "0.0.1",
+        "ip": "^1.1.5",
+        "muxrpc-validation": "^3.0.0",
+        "on-change-network": "0.0.2",
+        "on-wakeup": "^1.0.1",
+        "pull-notify": "^0.1.1",
+        "pull-ping": "^2.0.2",
+        "pull-stream": "^3.6.9",
+        "ssb-conn-db": "0.0.5",
+        "ssb-keys": "^7.1.3",
+        "ssb-ref": "^2.13.9",
+        "statistics": "^3.3.0"
+      },
+      "dependencies": {
+        "muxrpc-validation": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/muxrpc-validation/-/muxrpc-validation-3.0.0.tgz",
+          "integrity": "sha1-47bAMaetOA8CrWfZMG1PGz+NNdY=",
+          "requires": {
+            "pull-stream": "^2.28.3",
+            "zerr": "^1.0.1"
+          },
+          "dependencies": {
+            "pull-stream": {
+              "version": "2.28.4",
+              "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-2.28.4.tgz",
+              "integrity": "sha1-fql0E8FhnCC8O9+eEOkTR7AyU+Q=",
+              "requires": {
+                "pull-core": "~1.1.0"
+              }
+            }
+          }
+        },
+        "ssb-ref": {
+          "version": "2.13.9",
+          "resolved": "https://registry.npmjs.org/ssb-ref/-/ssb-ref-2.13.9.tgz",
+          "integrity": "sha512-TfatNqLvoP+eW/pMIbCmNcaoDq4R2k8jCtWkwDKx4AtluN/LwtyP931d5Mh+2gmzA04W7kxkr6f5ENGgdadMYg==",
+          "requires": {
+            "ip": "^1.1.3",
+            "is-canonical-base64": "^1.1.1",
+            "is-valid-domain": "~0.0.1",
+            "multiserver-address": "^1.0.1"
+          }
+        }
       }
     },
     "ssb-links": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "author": "Secure Scuttlebutt Consortium",
   "license": "AGPL-3.0",
   "dependencies": {
-    "@staltz/sbot-gossip": "^1.1.6",
     "app-root-path": "^2.1.0",
     "async": "^2.6.1",
     "bulk-require": "^1.0.1",
@@ -80,6 +79,7 @@
     "ssb-feed": "^2.3.0",
     "ssb-friends": "^3.1.7",
     "ssb-keys": "^7.1.3",
+    "ssb-legacy-conn": "1.0.12",
     "ssb-markdown": "^4.0.0",
     "ssb-mentions": "^0.5.0",
     "ssb-msgs": "^5.2.0",

--- a/server-process.js
+++ b/server-process.js
@@ -21,7 +21,7 @@ var fixPath = require('fix-path')
 
 var createSbot = require('ssb-server')
   .use(require('ssb-server/plugins/master'))
-  .use(require('ssb-server/plugins/gossip'))
+  .use(require('ssb-legacy-conn'))
   .use(require('ssb-server/plugins/replicate'))
   .use(require('ssb-server/plugins/no-auth'))
   .use(require('ssb-server/plugins/unix-socket'))


### PR DESCRIPTION
I've been working on the gossip plugin refactor/rewrite. `ssb-legacy-conn` is essentially the same functionality as `ssb-gossip`, but with its internals reworked with a new stack of libraries (notably, `ssb-conn-db` migrates the file `gossip.json` to `conn.json`). I'm using `ssb-legacy-conn` also in Manyverse.

Try out this PR branch before merging. Everything should functionally be the same, the one difference is that `gossip.json` is *read* but never *updated*, only `conn.json` is updated from now onwards. I'll be updating `ssb-legacy-conn` gradually until its internals are very easy to work with. Then it'll be easy to create alternative plugins, e.g. `ssb-better-conn`.