### PR TITLE
Use default SSBC stale settings

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,1 @@
 _extends: .github
-
-# Issues with these labels will never be considered stale
-# This overrides `exemptLabels` from https://github:ssbc/.github
-exemptLabels:
-  - pinned
-  - security
-  - enhancement
-  - bug
-  - performance
-


### PR DESCRIPTION
We have lots of open issues for things that (IMO) don't seem like they'll get worked on anytime soon, which distracts from the important issues that *do* need to get worked on. If you dig an issue or PR you can assign yourself to it and it won't go stale.

## Before

Issues with these labels *never* go stale:

- pinned
- security
- enhancement
- bug
- performance

## After

We return to the SSBC default, defined [here](https://github.com/ssbc/.github/blob/master/.github/stale.yml), so that issues with these labels never go stale:

- pinned
- security