### PR TITLE
Pretty-print redacted config with `console.dir`

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,7 @@ function setupContext (appName, opts, cb) {
 
   const redactedConfig = JSON.parse(JSON.stringify(ssbConfig))
   redactedConfig.keys.private = null
-  console.log(JSON.stringify(redactedConfig, null, 2))
+  console.dir(redactedConfig, { depth: null })
 
   if (opts.server === false) {
     cb && cb()


### PR DESCRIPTION
Adds syntax highlighting and a more compact output.

## Before

```
{
  "path": "/home/christianbundy/.ssb",
  "party": true,
  "timeout": 0,
  "pub": true,
  "local": true,
  "friends": {
    "dunbar": 150,
    "hops": 2
  },
  "gossip": {
    "connections": 3,
    "autoPopulate": false
  },
  "connections": {
    "outgoing": {
      "net": [
        {
          "transform": "shs"
        }
      ]
    },
    "incoming": {
      "net": [
        {
          "host": "::",
          "port": 8008,
          "scope": [
            "device",
            "local",
            "public"
          ],
          "transform": "shs"
        }
      ],
      "ws": [
        {
          "host": "::",
          "port": 8989,
          "scope": [
            "device",
            "local",
            "public"
          ],
          "transform": "shs"
        }
      ],
      "unix": [
        {
          "scope": "device",
          "transform": "noauth"
        }
      ]
    }
  },
  "timers": {
    "connection": 0,
    "reconnect": 5000,
    "ping": 300000,
    "handshake": 5000
  },
  "caps": {
    "shs": "1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=",
    "sign": null
  },
  "master": [],
  "logging": {
    "level": "notice"
  },
  "port": 8008,
  "blobsPort": 8989,
  "server": true,
  "plugins": {
    "ssb-identities": true,
    "ssb-names": true,
    "ssb-search": true
  },
  "_": [],
  "configs": [
    "/home/christianbundy/.ssb/config"
  ],
  "config": "/home/christianbundy/.ssb/config",
  "host": "::",
  "ws": {
    "host": "::",
    "port": 8989,
    "scope": [
      "device",
      "local",
      "public"
    ],
    "transform": "shs"
  },
  "keys": {
    "curve": "ed25519",
    "public": "+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519",
    "private": null,
    "id": "@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519"
  },
  "remote": "unix:/home/christianbundy/.ssb/socket:~noauth:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU="
}
```

## After

```js
{ path: '/home/christianbundy/.ssb',
  party: true,
  timeout: 0,
  pub: true,
  local: true,
  friends: { dunbar: 150, hops: 2 },
  gossip: { connections: 3, autoPopulate: false },
  connections:
   { outgoing: { net: [ { transform: 'shs' } ] },
     incoming:
      { net:
         [ { host: '::',
             port: 8008,
             scope: [ 'device', 'local', 'public' ],
             transform: 'shs' } ],
        ws:
         [ { host: '::',
             port: 8989,
             scope: [ 'device', 'local', 'public' ],
             transform: 'shs' } ],
        unix: [ { scope: 'device', transform: 'noauth' } ] } },
  timers:
   { connection: 0, reconnect: 5000, ping: 300000, handshake: 5000 },
  caps:
   { shs: '1KHLiKZvAvjbY1ziZEHMXawbCEIM6qwjCDm3VYRan/s=',
     sign: null },
  master: [],
  logging: { level: 'notice' },
  port: 8008,
  blobsPort: 8989,
  server: true,
  plugins:
   { 'ssb-identities': true, 'ssb-names': true, 'ssb-search': true },
  _: [],
  configs: [ '/home/christianbundy/.ssb/config' ],
  config: '/home/christianbundy/.ssb/config',
  host: '::',
  ws:
   { host: '::',
     port: 8989,
     scope: [ 'device', 'local', 'public' ],
     transform: 'shs' },
  keys:
   { curve: 'ed25519',
     public: '+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519',
     private: null,
     id: '@+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=.ed25519' },
  remote:
   'unix:/home/christianbundy/.ssb/socket:~noauth:+oaWWDs8g73EZFUMfW37R/ULtFEjwKN/DczvdYihjbU=' }
```