### PR TITLE
Stop sending console output to both terminals

### DIFF
--- a/assets/base.html
+++ b/assets/base.html
@@ -1,31 +1,5 @@
 <!DOCTYPE html>
 <html>
   <head></head>
-  <body>
-    <script>
-      // redirect console to main process
-      var electron = require('electron')
-      var localLog = console.log
-      var localError = console.error
-      var remoteLog = electron.remote.getGlobal('console').log
-      var remoteError = electron.remote.getGlobal('console').error
-
-      console.log = function (...args) {
-        localLog.apply(console, args)
-        remoteLog(...args)
-      }
-
-      console.error = function (...args) {
-        localError.apply(console, args)
-        remoteError(...args)
-      }
-
-      process.exit = electron.remote.app.quit
-      // redirect errors to stderr
-      window.addEventListener('error', function (e) {
-        e.preventDefault()
-        console.error(e.error.stack || 'Uncaught ' + e.error)
-      })
-    </script>
-  </body>
+  <body></body>
 </html>


### PR DESCRIPTION
Terminal output and browser console output are formatted differently, so
trying to send the same output to both consoles results in a bunch of
messages that look like:

```
%cmultiserver:ws %cListening on color: #FF6600:NaN%c +0ms :: 8989 color: #FF6600
```