### PR TITLE
Fix pull-resume pagination bug

### DIFF
--- a/lib/pull-resume.js
+++ b/lib/pull-resume.js
@@ -6,19 +6,19 @@ const extend = require('xtend')
 module.exports = {
   source: function (stream, { getResume, limit, filterMap }) {
     if (limit) {
-      let marker = { marker: true }
+      let marker = { marker: true, resume: null }
       let count = 0
+
       return pullCat([
         pull(
           stream,
+          filterMap,
+          pull.take(limit),
           pull.through(msg => {
             if (!msg.sync) {
               marker.resume = getResume(msg)
             }
-          }),
-          filterMap,
-          pull.take(limit),
-          pull.through(() => {
+
             count += 1
           })
         ),

--- a/lib/pull-resume.js
+++ b/lib/pull-resume.js
@@ -12,7 +12,6 @@ module.exports = {
       return pullCat([
         pull(
           stream,
-          filterMap,
           pull.take(limit),
           pull.through(msg => {
             if (!msg.sync) {
@@ -20,7 +19,8 @@ module.exports = {
             }
 
             count += 1
-          })
+          }),
+          filterMap
         ),
 
         pull(


### PR DESCRIPTION
The problem seems to be caused by the marker counter getting ahead of
the limit constrained by `pull.take()`. This moves both the filter and
the `pull.take()` before the marker counter, which ensures that if the
counters become out of sync the marker counter can only be behind --
never ahead.

Still unclear about why this changed between scuttlebot 12 and 13. :man_shrugging: 

Resolves #978 