### PR TITLE
Remove irrelevant prebuilds from build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
   },
   "build": {
     "appId": "org.ssbc.patchwork",
-    "buildDependenciesFromSource": "true",
+    "files": [
+      "!**/prebuilds/!(${os}-${arch})${/*}"
+    ],
     "linux": {
       "category": "Network"
     },


### PR DESCRIPTION
Previously @mmckegg had some awesome rules to keep the build artifact
size small, but when setting up the new build system I switched
everything back to their defaults (since we seemed to be hardcoding many
defaults anyway).

This commit removes prebuilds for other architectures so that we aren't
including ~30 MB of irrelevant binaries in each build artifact.

This also disables `buildDependenciesFromSource`, which is recommended
by Electron but disabled by default by electron-builder. If these
prebuilds give use trouble we can go back to building them all from
source, but this should make `npm install` quicker for most people on
most operating systems.