### PR TITLE
Shrink default non-expanded message size

### DIFF
--- a/styles/base/message.mcss
+++ b/styles/base/message.mcss
@@ -108,7 +108,7 @@ Message {
   section {
     margin: 0
     padding: 0 20px
-    max-height: 1500px
+    max-height: 500px
     overflow: hidden
     -expanded {
       max-height: none


### PR DESCRIPTION
**Warning:** subjectivity! I've noticed that the default unexpanded message size is often ~1.5 screen 

## Before

![Screenshot from 2019-05-09 12-47-51](https://user-images.githubusercontent.com/537700/57482121-b4f2a480-7258-11e9-96a3-aa5b092ae8aa.png)

![Screenshot from 2019-05-09 12-48-06](https://user-images.githubusercontent.com/537700/57482127-b8862b80-7258-11e9-8fc9-88042ddb5e06.png)

## After

![Screenshot from 2019-05-09 12-46-17](https://user-images.githubusercontent.com/537700/57482137-bcb24900-7258-11e9-8690-63f755cfc29f.png)
