### PR TITLE
Fix EXIF stripping via message compose input button

### DIFF
--- a/modules/blob/html/input.js
+++ b/modules/blob/html/input.js
@@ -11,7 +11,7 @@ module.exports = {
     return nest('blob.html.input', FileInput)
 
     function FileInput (onAdded, opts = {}) {
-      const { accept, private: isPrivate, removeExif: stripExif, resize, quality, multiple, maxSize } = opts
+      const { accept, private: isPrivate, stripExif = true, resize, quality, multiple, maxSize } = opts
 
       return h('input', {
         type: 'file',


### PR DESCRIPTION
It looks like previously we were stripping EXIF data when images were
dragged and dropped into the composer or pasted, but unfortunately this
default wasn't set for the input button itself. This resolves the issue
so that when an input button is created it defaults to `{ stripExif = true }`.

Should resolve #1022, and it seems to be working correctly now that I've tested it. I'd love if someone could so we're 200% sure it's resolved. :dancing_women: 