### PR TITLE
Remove electron-builder rules breaking AppImages

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,9 +104,6 @@
   },
   "build": {
     "appId": "org.ssbc.patchwork",
-    "files": [
-      "!**/prebuilds/!(${os}-${arch})${/*}"
-    ],
     "linux": {
       "category": "Network"
     },


### PR DESCRIPTION
During a call with @mixmix and @pietgeursen we disovered that this rule
was causing problems for AppImages on some operating systems (Ubuntu
16.04, specifically) and that removing this property solved the problem.

This increases the size of the build(s) but it's better than a broken
build. In the future we should add a new rule that decreases the build
size *without* breaking AppImages.