### PR TITLE
reduce build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
     "files": [
       "**/*",
       "!**/prebuilds${/*}",
-      "node_modules/sodium-native/prebuilds/${os}-${arch}/electron-69.node"
+      "node_modules/sodium-native/prebuilds/${os}-${arch}/electron-69.node",
+      "node_modules/leveldown/prebuilds/${os}-${arch}/node.napi.node"
     ],
     "extraFiles": [
       {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,18 @@
   },
   "build": {
     "appId": "org.ssbc.patchwork",
+    "files": [
+      "**/*",
+      "!**/prebuilds${/*}",
+      "node_modules/sodium-native/prebuilds/${os}-${arch}/electron-69.node"
+    ],
+    "extraFiles": [
+      {
+        "from": "node_modules/sodium-native/prebuilds/${os}-${arch}/",
+        "to": ".",
+        "filter": "libsodium.*"
+      }
+    ],
     "linux": {
       "category": "Network",
       "target": [


### PR DESCRIPTION
~fixes https://github.com/ssbc/patchwork/issues/1045 and (theoretically)~ reduces build size ~(even more!)~

- sodium-native _and (now) leveldown_ are the only dependencies using prebuilds
- the only sodium-native binding we need is `electron-69.node`
  - where `$(electron --abi) == 69`
- we also need the `libsodium.so.23` shared library
  - but we must copy this into the root directory of the build (outside the compiled binary file)
- the only leveldown binding we need is `node.napi.node`