### PR TITLE
add .deb build

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,17 @@
       "!**/prebuilds/!(${os}-${arch})${/*}"
     ],
     "linux": {
-      "category": "Network"
+      "category": "Network",
+      "target": [
+        "AppImage",
+        "snap",
+        "deb"
+      ]
+    },
+    "deb": {
+      "packageCategory": "net",
+      "priority": "optional",
+      "maintainer": "Michael Williams <michael.williams@enspiral.com>"
     },
     "dmg": {
       "icon": "build/dmg/icon.icns"


### PR DESCRIPTION
closes https://github.com/ssbc/patchwork/issues/983

- add deb as additional target for Linux builds
  - kept existing AppImage and snap defaults
- default .deb dependencies seem to be sufficient
- must have `maintainer` field, so i guess that's me =^.^=