### PR TITLE
Increase size of non-expanded messages to 2x width

### DIFF
--- a/styles/base/message.mcss
+++ b/styles/base/message.mcss
@@ -108,7 +108,7 @@ Message {
   section {
     margin: 0
     padding: 0 20px
-    max-height: 500px
+    max-height: 1170px
     overflow: hidden
     -expanded {
       max-height: none


### PR DESCRIPTION
The original value here was 1500px which felt too big, but I think 500
feels too small. I think that having the width as 2x the height seems
like a reasonable enough goldilocks number.

The width of this section is 585px, so double that is 1170px.