### PR TITLE
chore: have Travis only build `master`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
 
 script: npm test && npm run dist
 
+
 branches:
-  except:
-    - "/^v\\d+\\.\\d+\\.\\d+$/"
+  only:
+  - master


### PR DESCRIPTION
The previous config had Travis building pull requests *and* branches, which meant that pull requests of repo branches were done twice. Super wasteful of time and electricity. This changes the config so that we build `master` (for releases) and pull requests (for testing new code).