### PR TITLE
fix: ensure code blocks aren't cropped

### DIFF
--- a/styles/base/markdown.mcss
+++ b/styles/base/markdown.mcss
@@ -52,7 +52,6 @@ Markdown {
   (pre) {
     overflow: auto
     padding: 10px
-    max-height: 300px
   }
   (ul) {
     (p) {


### PR DESCRIPTION
This makes it much easier to read code in Patchwork. Previously you had to scroll a *ton* and only had a 300px tall window to read from.