### PR TITLE
fix: log when Patchwork is already running

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ var quitting = false
  */
 function quitIfAlreadyRunning () {
   if (!electron.app.requestSingleInstanceLock()) {
+    console.log('Patchwork is already running!')
+    console.log('Please close the existing instance before starting a new one.')
     return electron.app.quit()
   }
   electron.app.on('second-instance', (event, commandLine, workingDirectory) => {


### PR DESCRIPTION
Previously if you tried to start Patchwork from the command-line it
would just quit if there was already an instance of Patchwork running
somewhere. This adds some small debug output that should make it more
clear what's going on.