### PR TITLE
fix: reverse backward hidden dialog logic

### DIFF
--- a/lib/latest-update.js
+++ b/lib/latest-update.js
@@ -11,7 +11,7 @@ module.exports = function () {
   var version = packageInfo.version
   const checkForUpdate = () => {
     // Check whether notification has been hidden.
-    if (hidden() === false) {
+    if (hidden() === true) {
       // If so, stop the interval timer.
       updateCheck()
       // And `return` to quit this function.


### PR DESCRIPTION
@ahdinosaur apparently I didn't test that change well enough, my logic was reversed -- if the user hides the dialog box then we want to kill the timer. Previously this was trying to kill the timer if the box *wasn't* hidden, which was failing because this code runs before the timer is instantiated.

:bug: 