### PR TITLE
feat: render more than one large emoji

### DIFF
--- a/lib/depject/message/html/markdown.js
+++ b/lib/depject/message/html/markdown.js
@@ -113,15 +113,35 @@ function LoadingBlobHook (hasBlob) {
 
 function LargeEmojiHook () {
   return function (element) {
-    // do our best with a css selector
-    element.querySelectorAll('p > .Emoji:only-child').forEach(img => {
-      // unfortunately `only-child` doesn't take text nodes into account
-      // check to see if there is actually any text before or after before adding class
-      var before = img.previousSibling && img.previousSibling.textContent.trim()
-      var after = img.nextSibling && img.nextSibling.textContent.trim()
-      if (!before && !after) {
-        img.classList.add('-large')
+    // if a line has only emoji, we want them to be LARGE
+    //
+    // first select for all emoji as the first child of a paragraph
+    element.querySelectorAll('p > .Emoji:nth-child(1)').forEach(firstEmojiElement => {
+      // then collect all emoji siblings.
+      // if a sibling is not an emoji or an empty text node, early return.
+      var emojiElements = []
+      var nextNode = firstEmojiElement
+
+      // before we start, check that matched emoji element's previous sibling is empty text.
+      if (firstEmojiElement.previousSibling && firstEmojiElement.previousSibling.textContent.trim() !== '') return
+
+      while (nextNode !== null) {
+        switch (nextNode.nodeType) {
+          case document.ELEMENT_NODE:
+            if (nextNode.className !== 'Emoji') return
+            emojiElements.push(nextNode)
+            break
+          case document.TEXT_NODE:
+            if (nextNode.textContent.trim() !== '') return
+            break
+        }
+        nextNode = nextNode.nextSibling
       }
+
+      // set all emoji children to be LARGE
+      emojiElements.forEach(emojiElement => {
+        emojiElement.classList.add('-large')
+      })
     })
   }
 }


### PR DESCRIPTION
for example, on the "Emoji Check-In Thread"s,

- %1Bsk5y+FzgNw0Zr8winKBN0HPiYWiJQB2uI+n2X+Dbw=.sha256
- %buttk1WRl2AfDp7AU1oeEvGcTnWCm7lUJ+3bVXIJqkk=.sha256

we've been posting 1-3 emojis, but our "large emoji" code only handles single emojis.

this pull request updates the "large emoji" code to handle cases with multiple emojis on the same line. which also is how other apps work, e.g. Facebook Messenger. :smiley_cat:

i tried to make the implementation as efficent as possible, but maybe this could be done better, i'm not sure.

other thread with test cases: %LAGvVzSNA/gbize/f+UeJYDEBIqWIMMDmvFZcpIY1Fk=.sha256

:heart: