### PR TITLE
fix: workaround bug where node-emoji returns extra colons

### DIFF
--- a/lib/depject/message/html/markdown.js
+++ b/lib/depject/message/html/markdown.js
@@ -50,7 +50,9 @@ exports.create = function (api) {
           if (emojiMentions[emoji]) {
             return renderEmoji(emoji, api.blob.sync.url(emojiMentions[emoji]))
           } else {
-            return `<span class="Emoji">${nodeEmoji.get(emoji)}</span>`
+            // https://github.com/omnidan/node-emoji/issues/76
+            const emojiCharacter = nodeEmoji.get(emoji).replace(/:/g, '')
+            return `<span class="Emoji">${emojiCharacter}</span>`
           }
         },
         toUrl: (id) => {


### PR DESCRIPTION
I created a bug report at https://github.com/omnidan/node-emoji/issues/76 but this is a workaround.

## Before

![Screenshot from 2019-06-15 09-08-54](https://user-images.githubusercontent.com/537700/59553687-53a3ac80-8f4d-11e9-816d-42bfe550aa8c.png)

## After

![Screenshot from 2019-06-15 09-08-30](https://user-images.githubusercontent.com/537700/59553689-58686080-8f4d-11e9-89a9-d51f79fd0012.png)
