### PR TITLE
Use system font

### DIFF
--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -150,7 +150,7 @@ module.exports = function (config) {
     h('style', {
       innerHTML: computed(api.settings.obs.get('patchwork.fontFamily'), family => {
         if (family) {
-          return 'body, button, input, select, textarea { font-family: ' + family + ';}'
+          return 'body, input, select { font-family: ' + family + ';}'
         }
       })
     })

--- a/styles/base/base.mcss
+++ b/styles/base/base.mcss
@@ -45,6 +45,9 @@ a {
 * {
   box-sizing: border-box
 }
+html, select, input {
+  font-family: system-ui, sans-serif
+}
 ::-webkit-file-upload-button {
   font-family: inherit
 }

--- a/styles/base/base.mcss
+++ b/styles/base/base.mcss
@@ -45,7 +45,7 @@ a {
 * {
   box-sizing: border-box
 }
-html, select, input {
+html, input, select {
   font-family: system-ui, sans-serif
 }
 ::-webkit-file-upload-button {

--- a/styles/base/main-window.mcss
+++ b/styles/base/main-window.mcss
@@ -76,7 +76,6 @@ MainWindow {
         padding: 4px 10px
         border-radius: 3px
         font-size: 120%
-        font-weight: 200
         cursor: pointer
         margin-left: 8px
         text-decoration: none !important
@@ -121,7 +120,6 @@ MainWindow {
       text-align: center
       font-size: 20px
       letter-spacing: 1px
-      font-weight: 200
       -webkit-app-region: drag
       position: relative
       span.title {


### PR DESCRIPTION
More notes in the commits, but the gist is that most operating systems bundle a default font that's better than what Electron uses (I think Arial?). Instead of hardcoding our favorite OS-specific fonts this lets us use the default UI font of the user's operating system, falling back to sans-serif if necessary.

![Screenshot of Patchwork's homepage using a slightly different font, which is my default operating system font.](https://user-images.githubusercontent.com/537700/59554306-e1839580-8f55-11e9-9bf9-54e165bc377e.png)
