### PR TITLE
refactor: encode emoji suggestion as character, not shortcode

### DIFF
--- a/lib/depject/suggest.js
+++ b/lib/depject/suggest.js
@@ -33,7 +33,7 @@ exports.create = function (api) {
             return {
               title: h('span.Emoji', result.emoji),
               subtitle: result.key,
-              value: `:${result.key}:`
+              value: result.emoji
             }
           }))
         }


### PR DESCRIPTION
Previously when you selected a suggestion it would add the shortcode to
the composer, which was *fine* but means that we all have to agree on
shortcodes. This changes it so that the emoji suggestions put the actual
emoji into the composer.

Note that this doesn't stop someone from manually typing in `:ghost:` or
something, but maybe in the future we could replace those shortcodes
with actual emoji so that we're never publishing shortcodes to our
feeds.

Originally brought up by @cinnamon-bun here:

> If we're changing the input (affecting the data that gets into the SSB
> message) it seems safer to use unicode chars as the canonical format because
>
> 1. The shortcode libraries generally lag behind the unicode emoji standard
> 2. The unicode emoji standard is more well-defined than shortcode names,
>    which might not match across different clients
>
> -- https://github.com/ssbc/ssb-markdown/pull/37#issuecomment-502216628