### PR TITLE
build: clarify support for Node.js Active LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ matrix:
     - os: osx
       osx_image: xcode9.4
       language: node_js
-      node_js: 10
+      node_js: lts/*
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
   
     - os: linux
       language: node_js
-      node_js: 10
+      node_js: lts/*
 
     - os: windows
       language: node_js
-      node_js: 10
+      node_js: lts/*
       filter_secrets: false
 
 cache:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -3,11 +3,10 @@
 The readme contains some information on the simplest installation methods, but
 you can also install Patchwork by fetching from Git and building from source.
 
-
 ## Dependencies
 
 - Git
-- Node.js (>= 6)
+- Node.js ([Active LTS][node-active-lts])
 - npm or Yarn
 
 ### Debian / Ubuntu
@@ -63,3 +62,5 @@ With yarn:
 ```shell
 yarn
 ```
+
+[node-active-lts]: https://github.com/nodejs/Release#release-schedule


### PR DESCRIPTION
In the past the install file said we supported v6+ but Travis only ran
tests for Node 10. I think it would be great to support older versions
of Node when possible but that since we don't have many resources for
maintenance and support we should clarify that this is only guaranteed
to work on the Node.js Active LTS release (currently Node 10).