### PR TITLE
feat: make alt text visually accessible

### DIFF
--- a/lib/depject/message/html/markdown.js
+++ b/lib/depject/message/html/markdown.js
@@ -39,7 +39,7 @@ exports.create = function (api) {
       })
     }
 
-    return h('Markdown', {
+    const output = h('Markdown', {
       classList,
       hooks: [
         LoadingBlobHook(api.blob.obs.has),
@@ -74,6 +74,22 @@ exports.create = function (api) {
         imageLink: (id) => id
       })
     })
+
+    const imgs = output.querySelectorAll('img')
+    imgs.forEach(img => {
+      if (img.alt.length === 0) {
+        return
+      }
+
+      const newNode = h('figure', [
+        img.cloneNode(),
+        h('figcaption', { 'aria-role': 'hidden' }, img.alt)
+      ])
+
+      img.parentNode.replaceChild(newNode, img)
+    })
+
+    return output
   }
 
   function renderEmoji (emoji, url) {

--- a/styles/base/base.mcss
+++ b/styles/base/base.mcss
@@ -59,12 +59,3 @@ Emoji {
   }
 }
 
-figure {
-  margin: 0
-  padding: 0
-}
-
-figcaption {
-  margin-bottom: 1rem
-  color: #527b90
-}

--- a/styles/base/base.mcss
+++ b/styles/base/base.mcss
@@ -58,3 +58,13 @@ Emoji {
     font-size: 2rem
   }
 }
+
+figure {
+  margin: 0
+  padding: 0
+}
+
+figcaption {
+  margin-bottom: 1rem
+  color: #527b90
+}

--- a/styles/base/markdown.mcss
+++ b/styles/base/markdown.mcss
@@ -63,6 +63,14 @@ Markdown {
       max-height: none
     }
   }
+  (figure) {
+    margin: 0
+    padding: 0
+    display: inline-block
+  }
+  (figcaption) {
+    margin: 1rem
+  }
 
   word-break: break-word
 }

--- a/styles/dark/markdown.mcss
+++ b/styles/dark/markdown.mcss
@@ -49,4 +49,7 @@ Markdown {
       }
     }
   }
+  (figure) {
+    border: 1px solid #2d2c2c
+  }
 }

--- a/styles/light/markdown.mcss
+++ b/styles/light/markdown.mcss
@@ -25,4 +25,7 @@ Markdown {
       }
     }
   }
+  (figure) {
+    border: 1px solid #eee
+  }
 }


### PR DESCRIPTION
I've seen that Dan has been adding captions to lots of his images
lately, which is super rad, but it's a bummer that he has to put the
descriptions in both the alt text *and* a secondary paragraph to make it
visually accessible.

This change takes the alt text and puts it into a `<figcaption>` that's
hidden from accessibility tools, that way screen readers see the image
alt text but people using Scuttlebutt visually are still able to see the
alt text that the community is adding to their images.

My hope is that this highlights the utility behind alt text and inspires
people to describe their visual data in a way that can be better
understood by accessibility tools.

![Screenshot from 2019-06-18 09-22-42](https://user-images.githubusercontent.com/537700/59703035-ee9ac180-91ad-11e9-91a3-a85b47222e41.png)

![Screenshot from 2019-06-18 09-23-26](https://user-images.githubusercontent.com/537700/59703045-f22e4880-91ad-11e9-9afc-1ecc2fb36a10.png)

![Screenshot from 2019-06-18 09-30-25](https://user-images.githubusercontent.com/537700/59703055-f65a6600-91ad-11e9-9bb0-aebd45583ced.png)

![Screenshot from 2019-06-18 09-30-44](https://user-images.githubusercontent.com/537700/59703103-07a37280-91ae-11e9-82e3-17f54751fd19.png)

I don't remember where I got the blue-ish caption color from, but it's somewhere else in the interface too. Maybe from "active channels" header on the left sidebar.