### PR TITLE
fix: don't show gatherings as private in the preview

### DIFF
--- a/lib/depject/gathering/sheet/edit.js
+++ b/lib/depject/gathering/sheet/edit.js
@@ -131,7 +131,7 @@ exports.create = function (api) {
               publiclyEditable: true,
               value: {
                 author: api.keys.sync.id(),
-                private: true,
+                private: false, // patchwork can only make public gatherings
                 content: {
                   type: 'gathering',
                   recps: participants


### PR DESCRIPTION
Display only bug. Looks like at some point a rogue find-replace made the gatherings preview box show all gatherings as private.

<img width="804" alt="Screen Shot 2019-06-27 at 1 00 29 PM" src="https://user-images.githubusercontent.com/66834/60226140-ffe67b00-98dd-11e9-9b3f-c0c4074edcea.png">

This PR reverts the change.