### PR TITLE
styles: revert emoji back to old size before NotoColorEmoji

### DIFF
--- a/lib/depject/suggest.js
+++ b/lib/depject/suggest.js
@@ -1,7 +1,7 @@
 const nest = require('depnest')
 var addSuggest = require('suggest-box')
 var resolve = require('mutant/resolve')
-var h = require('hyperscript')
+var h = require('mutant/h')
 const emoji = require('node-emoji')
 
 exports.needs = nest({
@@ -31,7 +31,7 @@ exports.create = function (api) {
           cb(null, emoji.search(word).slice(0, 100).map(function (result) {
             // result = { key:  emoji}
             return {
-              title: h('span.Emoji', result.emoji),
+              title: h('span Emoji -suggest', result.emoji),
               subtitle: result.key,
               value: result.emoji
             }

--- a/styles/base/base.mcss
+++ b/styles/base/base.mcss
@@ -54,6 +54,11 @@ html, input, select {
 
 Emoji {
   font-family: NotoColorEmoji
+  font-size: 120%
+  line-height: 1
+  -suggest {
+    line-height: 1.4
+  }
   -large {
     font-size: 2rem
   }


### PR DESCRIPTION
This PR makes the emoji appear slightly bigger. I attempted to match the size of emojis before the Noto emoji were added.

## Before:

<img width="791" alt="Screen Shot 2019-07-02 at 5 11 28 PM" src="https://user-images.githubusercontent.com/66834/60484986-7e348a00-9cef-11e9-9147-6fbc0b174c43.png">

<img width="700" alt="Screen Shot 2019-07-02 at 5 34 55 PM" src="https://user-images.githubusercontent.com/66834/60485060-c3f15280-9cef-11e9-8fd0-d04cf050fdc2.png">


## After:

<img width="795" alt="Screen Shot 2019-07-02 at 5 12 19 PM" src="https://user-images.githubusercontent.com/66834/60484993-842a6b00-9cef-11e9-9dbf-2d9b761d23f7.png">

<img width="701" alt="Screen Shot 2019-07-02 at 5 34 00 PM" src="https://user-images.githubusercontent.com/66834/60485081-d23f6e80-9cef-11e9-9a1f-162a16415c6a.png">
