### PR TITLE
Show content warnings and allow expand/contract

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -88,7 +88,7 @@ function setupContextMenuAndSpellCheck (config, { navigate, get }) {
 
       if (ref.isBlob(extractedRef) && menuInfo.hasImageContents) {
         const copyEmbed = new MenuItem({
-          label: `Copy Embed Markdown`,
+          label: 'Copy Embed Markdown',
           click: () => {
             // Omit the mailto: portion of the link; we just want the address
             clipboard.writeText(`![${menuInfo.titleText}](${extractedRef})`)

--- a/lib/depject/message/html/layout/default.js
+++ b/lib/depject/message/html/layout/default.js
@@ -74,15 +74,33 @@ exports.create = function (api) {
       classList.push('-unread')
     }
 
+    let cw = msg.value.content.contentWarning
+    if (typeof cw !== 'string' || cw.length === 0) {
+      cw = undefined;
+    } else {
+      // TODO: emoji shortcodes?
+      // TODO: truncate very long content warning, maybe use max-height?
+      classList.push('-hasContentWarning');
+    }
+
     return h('div', {
       classList,
       hooks
     }, [
       messageHeader(msg, { replyInfo, priority }),
-      h('section', {
+      cw
+        ? h('a.contentWarning',
+          {
+            href: '#',
+            'ev-click': toggleAndTrack(expanded),
+          },
+          cw,
+        )
+        : undefined,
+      h('section.content', {
         classList: [when(expanded, '-expanded')],
         hooks: [ExpanderHook(needsExpand)]
-      }, [content]),
+      }, content),
       computed(msg.key, (key) => {
         if (ref.isMsg(key)) {
           return h('footer', [

--- a/lib/depject/message/html/layout/default.js
+++ b/lib/depject/message/html/layout/default.js
@@ -76,11 +76,11 @@ exports.create = function (api) {
 
     let cw = msg.value.content.contentWarning
     if (typeof cw !== 'string' || cw.length === 0) {
-      cw = undefined;
+      cw = undefined
     } else {
       // TODO: emoji shortcodes?
       // TODO: truncate very long content warning, maybe use max-height?
-      classList.push('-hasContentWarning');
+      classList.push('-hasContentWarning')
     }
 
     return h('div', {
@@ -92,9 +92,9 @@ exports.create = function (api) {
         ? h('a.contentWarning',
           {
             href: '#',
-            'ev-click': toggleAndTrack(expanded),
+            'ev-click': toggleAndTrack(expanded)
           },
-          cw,
+          cw
         )
         : undefined,
       h('section.content', {

--- a/lib/depject/message/html/layout/mini.js
+++ b/lib/depject/message/html/layout/mini.js
@@ -73,7 +73,7 @@ exports.create = function (api) {
       messageHeader(msg, {
         replyInfo, priority, miniContent
       }),
-      h('section', {
+      h('section.content', {
         classList: [when(expanded, '-expanded')],
         hooks: [ExpanderHook(needsExpand)]
       }, [content]),

--- a/lib/depject/message/html/markdown.js
+++ b/lib/depject/message/html/markdown.js
@@ -60,8 +60,8 @@ exports.create = function (api) {
           if (link && ref.isBlob(link.link)) {
             const url = api.blob.sync.url(link.link)
             const query = {}
-            if (link.query && link.query.unbox) query['unbox'] = link.query.unbox
-            if (typeLookup[link.link]) query['contentType'] = typeLookup[link.link]
+            if (link.query && link.query.unbox) query.unbox = link.query.unbox
+            if (typeLookup[link.link]) query.contentType = typeLookup[link.link]
             return url + '?' + querystring.stringify(query)
           } else if (link || id.startsWith('#') || id.startsWith('?')) {
             return id

--- a/lib/depject/message/html/missing.js
+++ b/lib/depject/message/html/missing.js
@@ -45,7 +45,7 @@ exports.create = function (api) {
         ])
       ]),
       h('section', [
-        h('p', [i18n(`The author of this message could be outside of your follow range or they may be blocked.`)])
+        h('p', [i18n('The author of this message could be outside of your follow range or they may be blocked.')])
       ])
     ])
 

--- a/lib/depject/message/html/render/attending.js
+++ b/lib/depject/message/html/render/attending.js
@@ -22,7 +22,7 @@ exports.create = function (api) {
     render: function about (msg, opts) {
       if (!isRenderable(msg)) return
 
-      const action = msg.value.content.attendee.remove ? `can't attend` : 'is attending'
+      const action = msg.value.content.attendee.remove ? 'can\'t attend' : 'is attending'
       const target = msg.value.content.about
       const title = api.about.obs.latestValue(target, 'title')
       const element = api.message.html.layout(msg, extend({

--- a/lib/depject/message/html/render/gathering.js
+++ b/lib/depject/message/html/render/gathering.js
@@ -91,11 +91,11 @@ exports.create = function (api) {
             h('button -attend', {
               disabled: computed([attending, disableActions], (...args) => args.some(Boolean)),
               'ev-click': send(publishAttending, msg)
-            }, `Attending`),
+            }, 'Attending'),
             h('button -attend', {
               disabled: disableActions,
               'ev-click': send(publishNotAttending, msg)
-            }, `Can't Attend`)
+            }, 'Can\'t Attend')
           ])
         ]),
         h('div.location', markdown(about.location)),

--- a/lib/depject/page/html/render/profile.js
+++ b/lib/depject/page/html/render/profile.js
@@ -179,11 +179,11 @@ exports.create = function (api) {
 
           when(contact.noIncoming,
             h('section -distanceWarning', [
-              h('h1', i18n(`You don't follow anyone who follows this person`)),
+              h('h1', i18n('You don\'t follow anyone who follows this person')),
               h('p', i18n('You might not be seeing their latest messages. You could try joining a pub that they are a member of.')),
               when(contact.hasOutgoing,
                 h('p', i18n('However, since they follow someone that follows you, they should be able to see your posts.')),
-                h('p', i18n(`They might not be able to see your posts either.`))
+                h('p', i18n('They might not be able to see your posts either.'))
               )
             ]),
             when(contact.noOutgoing,

--- a/lib/depject/profile/html/preview.js
+++ b/lib/depject/profile/html/preview.js
@@ -66,7 +66,7 @@ exports.create = function (api) {
             ]),
             when(contact.noIncoming,
               h('section -distanceWarning', [
-                '⚠️ ', i18n(`You don't follow anyone who follows this person`)
+                '⚠️ ', i18n('You don\'t follow anyone who follows this person')
               ]),
               when(contact.mutualFriendsCount,
                 h('section -mutualFriends', [

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -157,7 +157,7 @@ module.exports = function (config) {
   document.head.appendChild(
     h('style', {
       innerHTML: computed(api.settings.obs.get('patchwork.theme', 'light'), themeName => {
-        return themes[themeName] || themes['light']
+        return themes[themeName] || themes.light
       })
     })
   )
@@ -170,7 +170,7 @@ module.exports = function (config) {
           dark: 'monokai'
         }
 
-        const syntaxTheme = syntaxThemeOptions[themeName] || syntaxThemeOptions['light']
+        const syntaxTheme = syntaxThemeOptions[themeName] || syntaxThemeOptions.light
         return requireStyle(`highlight.js/styles/${syntaxTheme}.css`)
       })
     })

--- a/lib/plugins/profile.js
+++ b/lib/plugins/profile.js
@@ -26,14 +26,14 @@ exports.init = function (ssb) {
       parallel([(done) => {
         ssb.about.socialValue({ dest: id, key: 'name' }, (err, value) => {
           if (err) return done(err)
-          result['name'] = value
+          result.name = value
           done()
         })
       }, (done) => {
         ssb.about.socialValue({ dest: id, key: 'image' }, (err, value) => {
           if (err) return done(err)
           if (value && value instanceof Object && value.link) value = value.link
-          result['image'] = value
+          result.image = value
           done()
         })
       }], (err) => {

--- a/styles/base/message.mcss
+++ b/styles/base/message.mcss
@@ -118,7 +118,11 @@ Message {
       }
     }
   }
-  section {
+  a.contentWarning {
+    padding: 10px 20px
+    font-weight: bold
+  }
+  section.content {
     margin: 0
     padding: 0 20px
     max-height: 1170px
@@ -292,5 +296,17 @@ Message {
   }
   -new, -unread {
     z-index: 1
+  }
+  -hasContentWarning {
+    section.content {
+      max-height: 0px
+    }
+    footer {
+      div.expander {
+          -webkit-mask-image: none !important
+          padding-top: 0px !important
+          margin-top: 0px !important
+      }
+    }
   }
 }

--- a/styles/dark/message.mcss
+++ b/styles/dark/message.mcss
@@ -79,6 +79,9 @@ Message {
       }
     }
   }
+  a.contentWarning {
+    background: #000
+  }
   a.backlink {
     padding: 10px 20px
     background: #2d2c2c

--- a/styles/light/message.mcss
+++ b/styles/light/message.mcss
@@ -69,6 +69,9 @@ Message {
       }
     }
   }
+  a.contentWarning {
+    background: #ddd
+  }
   a.backlink {
     border-top: 1px solid #eee
     padding: 10px 15px


### PR DESCRIPTION
First pass at CW support!  Only for reading, not writing yet.

This may change slightly as the spec solidifies for CWs.

When messages have a `contentWarning` field, this renders the warning as a bar above the message.  You can click the bar to expand and contract the message.  Messages start closed by default.

This reuses the existing expand/contract mechanism ("see more", "see less").

Next steps:
* Improve CSS styles and colors
* Test what happens when there's weird stuff in the CW text like newlines, Markdown, HTML, very long CWs, etc.  CWs should be treated as a single line of plain text (according to the current spec, still in flux)
* Maybe handle emoji shortcodes in the CW text
* Allow creating posts with CWs
* Add a setting to control if they're open or closed by default
* Include CW text in the fulltext index for searching purposes

Fancy stuff, later:
* Remember the open/closed state of each CW post
* Fancy settings to auto open/close CWs by author, or by substring match in the CW text, like a blocklist / allowlist

✨  This was a joint effort with @mmckegg and @marylychee  ✨ 