### PR TITLE
Fix depject with bulk-require tree

### DIFF
--- a/lib/depject/index.js
+++ b/lib/depject/index.js
@@ -1,111 +1,214 @@
 module.exports = {
-  patchwork: [
-    require('./contact/async.js'),
-    require('./contact/html/follow-toggle.js'),
-    require('./contact/obs.js'),
-    require('./profile/obs/contact.js'),
-    require('./profile/obs/recently-updated.js'),
-    require('./profile/obs/rank.js'),
-    require('./profile/html/person.js'),
-    require('./profile/html/preview.js'),
-    require('./profile/async/avatar.js'),
-    require('./profile/async/suggest.js'),
-    require('./profile/sheet/edit.js'),
-    require('./feed/obs/recent.js'),
-    require('./feed/html/rollup.js'),
-    require('./feed/html/follow-warning.js'),
-    require('./feed/html/meta-summary.js'),
-    require('./about/html/link.js'),
-    require('./about/html/image.js'),
-    require('./about/async/latest-values.js'),
-    require('./about/sync.js'),
-    require('./about/obs.js'),
-    require('./about/sync/short-feed-id.js'),
-    require('./channel/obs/recent.js'),
-    require('./channel/obs/subscribed.js'),
-    require('./channel/obs/subscribers.js'),
-    require('./channel/html/link.js'),
-    require('./channel/html/subscribe-toggle.js'),
-    require('./channel/html/preview.js'),
-    require('./channel/async/suggest.js'),
-    require('./channel/sync/normalize.js'),
-    require('./backlinks/obs.js'),
-    require('./app/link-preview.js'),
-    require('./app/html/progress-notifier.js'),
-    require('./app/html/search.js'),
-    require('./app/sync/external-handler/git.js'),
-    require('./app/views.js'),
-    require('./app/fullscreen.js'),
-    require('./progress/html/render.js'),
-    require('./progress/html/peer.js'),
-    require('./progress/obs.js'),
-    require('./message/obs/author.js'),
-    require('./message/obs/likes.js'),
-    require('./message/obs/get.js'),
-    require('./message/obs/name.js'),
-    require('./message/html/link.js'),
-    require('./message/html/metas.js'),
-    require('./message/html/forks.js'),
-    require('./message/html/timestamp.js'),
-    require('./message/html/actions.js'),
-    require('./message/html/missing.js'),
-    require('./message/html/markdown.js'),
-    require('./message/html/compose.js'),
-    require('./message/html/decorate/context-menu.js'),
-    require('./message/html/render/channel.js'),
-    require('./message/html/render/issue.js'),
-    require('./message/html/render/blog.js'),
-    require('./message/html/render/made-changes.js'),
-    require('./message/html/render/following.js'),
-    require('./message/html/render/gathering.js'),
-    require('./message/html/render/vote.js'),
-    require('./message/html/render/post.js'),
-    require('./message/html/render/about.js'),
-    require('./message/html/render/attending.js'),
-    require('./message/html/render/zzz-fallback.js'),
-    require('./message/html/references.js'),
-    require('./message/html/layout/default.js'),
-    require('./message/html/layout/mini.js'),
-    require('./message/async/publish.js'),
-    require('./message/async/name.js'),
-    require('./message/sync/timestamp.js'),
-    require('./message/sync/root.js'),
-    require('./message/sync/unbox.js'),
-    require('./message/sheet/preview.js'),
-    require('./gathering/sheet/edit.js'),
-    require('./lib/timeAgo.js'),
-    require('./page/html/render/message.js'),
-    require('./page/html/render/channels.js'),
-    require('./page/html/render/channel.js'),
-    require('./page/html/render/settings.js'),
-    require('./page/html/render/profile.js'),
-    require('./page/html/render/participating.js'),
-    require('./page/html/render/private.js'),
-    require('./page/html/render/gatherings.js'),
-    require('./page/html/render/public.js'),
-    require('./page/html/render/all.js'),
-    require('./page/html/render/mentions.js'),
-    require('./page/html/render/your-posts.js'),
-    require('./page/html/render/search.js'),
-    require('./page/html/render/tag.js'),
-    require('./sbot.js'),
-    require('./suggest.js'),
-    require('./blob/obs/has.js'),
-    require('./blob/html/input.js'),
-    require('./blob/sync/url.js'),
-    require('./invite/sheet.js'),
-    require('./invite/invite.js'),
-    require('./invite/dhtAcceptSheet.js'),
-    require('./invite/dhtCreateSheet.js'),
-    require('./intl/sync/i18n.js'),
-    require('./tag/html/tag.js'),
-    require('./tag/async/suggest.js'),
-    require('./keys.js'),
-    require('./sheet/tags/renderTags.js'),
-    require('./sheet/tags/tags.js'),
-    require('./sheet/tags/renderTaggers.js'),
-    require('./sheet/editTags.js'),
-    require('./sheet/display.js'),
-    require('./sheet/profiles.js')
-  ]
+  patchwork: {
+    about: {
+      async: {
+        'latest-values': require('./about/async/latest-values.js')
+      },
+      html: {
+        image: require('./about/html/image.js'),
+        link: require('./about/html/link.js')
+      },
+      obs: require('./about/obs.js'),
+      sync: require('./about/sync.js')
+    },
+    app: {
+      fullscreen: require('./app/fullscreen.js'),
+      html: {
+        'progress-notifier': require('./app/html/progress-notifier.js'),
+        search: require('./app/html/search.js')
+      },
+      'link-preview': require('./app/link-preview.js'),
+      sync: {
+        'external-handler': {
+          git: require('./app/sync/external-handler/git.js')
+        }
+      },
+      views: require('./app/views.js')
+    },
+    backlinks: {
+      obs: require('./backlinks/obs.js')
+    },
+    blob: {
+      html: {
+        input: require('./blob/html/input.js')
+      },
+      obs: {
+        has: require('./blob/obs/has.js')
+      },
+      sync: {
+        url: require('./blob/sync/url.js')
+      }
+    },
+    channel: {
+      async: {
+        suggest: require('./channel/async/suggest.js')
+      },
+      html: {
+        link: require('./channel/html/link.js'),
+        preview: require('./channel/html/preview.js'),
+        'subscribe-toggle': require('./channel/html/subscribe-toggle.js')
+      },
+      obs: {
+        recent: require('./channel/obs/recent.js'),
+        subscribed: require('./channel/obs/subscribed.js'),
+        subscribers: require('./channel/obs/subscribers.js')
+      },
+      sync: {
+        normalize: require('./channel/sync/normalize.js')
+      }
+    },
+    contact: {
+      async: require('./contact/async.js'),
+      html: {
+        'follow-toggle': require('./contact/html/follow-toggle.js')
+      },
+      obs: require('./contact/obs.js')
+    },
+    feed: {
+      html: {
+        'follow-warning': require('./feed/html/follow-warning.js'),
+        'meta-summary': require('./feed/html/meta-summary.js'),
+        rollup: require('./feed/html/rollup.js')
+      },
+      obs: {
+        recent: require('./feed/obs/recent.js')
+      }
+    },
+    gathering: {
+      sheet: {
+        edit: require('./gathering/sheet/edit.js')
+      }
+    },
+    intl: {
+      sync: {
+        i18n: require('./intl/sync/i18n.js')
+      }
+    },
+    invite: {
+      dhtAcceptSheet: require('./invite/dhtAcceptSheet.js'),
+      dhtCreateSheet: require('./invite/dhtCreateSheet.js'),
+      invite: require('./invite/invite.js'),
+      sheet: require('./invite/sheet.js')
+    },
+    keys: require('./keys.js'),
+    lib: {
+      timeAgo: require('./lib/timeAgo.js')
+    },
+    message: {
+      async: {
+        name: require('./message/async/name.js'),
+        publish: require('./message/async/publish.js')
+      },
+      html: {
+        actions: require('./message/html/actions.js'),
+        compose: require('./message/html/compose.js'),
+        decorate: {
+          'context-menu': require('./message/html/decorate/context-menu.js')
+        },
+        forks: require('./message/html/forks.js'),
+        layout: {
+          default: require('./message/html/layout/default.js'),
+          mini: require('./message/html/layout/mini.js')
+        },
+        link: require('./message/html/link.js'),
+        markdown: require('./message/html/markdown.js'),
+        metas: require('./message/html/metas.js'),
+        missing: require('./message/html/missing.js'),
+        references: require('./message/html/references.js'),
+        render: {
+          about: require('./message/html/render/about.js'),
+          attending: require('./message/html/render/attending.js'),
+          blog: require('./message/html/render/blog.js'),
+          channel: require('./message/html/render/channel.js'),
+          following: require('./message/html/render/following.js'),
+          gathering: require('./message/html/render/gathering.js'),
+          issue: require('./message/html/render/issue.js'),
+          'made-changes': require('./message/html/render/made-changes.js'),
+          post: require('./message/html/render/post.js'),
+          vote: require('./message/html/render/vote.js'),
+          'zzz-fallback': require('./message/html/render/zzz-fallback.js')
+        },
+        timestamp: require('./message/html/timestamp.js')
+      },
+      obs: {
+        author: require('./message/obs/author.js'),
+        get: require('./message/obs/get.js'),
+        likes: require('./message/obs/likes.js'),
+        name: require('./message/obs/name.js')
+      },
+      sheet: {
+        preview: require('./message/sheet/preview.js')
+      },
+      sync: {
+        root: require('./message/sync/root.js'),
+        timestamp: require('./message/sync/timestamp.js'),
+        unbox: require('./message/sync/unbox.js')
+      }
+    },
+    page: {
+      html: {
+        render: {
+          all: require('./page/html/render/all.js'),
+          channel: require('./page/html/render/channel.js'),
+          channels: require('./page/html/render/channels.js'),
+          gatherings: require('./page/html/render/gatherings.js'),
+          mentions: require('./page/html/render/mentions.js'),
+          message: require('./page/html/render/message.js'),
+          participating: require('./page/html/render/participating.js'),
+          private: require('./page/html/render/private.js'),
+          profile: require('./page/html/render/profile.js'),
+          public: require('./page/html/render/public.js'),
+          search: require('./page/html/render/search.js'),
+          settings: require('./page/html/render/settings.js'),
+          tag: require('./page/html/render/tag.js'),
+          'your-posts': require('./page/html/render/your-posts.js')
+        }
+      }
+    },
+    profile: {
+      async: {
+        avatar: require('./profile/async/avatar.js'),
+        suggest: require('./profile/async/suggest.js')
+      },
+      html: {
+        person: require('./profile/html/person.js'),
+        preview: require('./profile/html/preview.js')
+      },
+      obs: {
+        contact: require('./profile/obs/contact.js'),
+        rank: require('./profile/obs/rank.js'),
+        'recently-updated': require('./profile/obs/recently-updated.js')
+      },
+      sheet: {
+        edit: require('./profile/sheet/edit.js')
+      }
+    },
+    progress: {
+      html: {
+        peer: require('./progress/html/peer.js'),
+        render: require('./progress/html/render.js')
+      },
+      obs: require('./progress/obs.js')
+    },
+    sbot: require('./sbot.js'),
+    sheet: {
+      display: require('./sheet/display.js'),
+      editTags: require('./sheet/editTags.js'),
+      profiles: require('./sheet/profiles.js'),
+      tags: {
+        renderTaggers: require('./sheet/tags/renderTaggers.js'),
+        renderTags: require('./sheet/tags/renderTags.js'),
+        tags: require('./sheet/tags/tags.js')
+      }
+    },
+    suggest: require('./suggest.js'),
+    tag: {
+      async: {
+        suggest: require('./tag/async/suggest.js')
+      },
+      html: {
+        tag: require('./tag/html/tag.js')
+      }
+    }
+  }
 }


### PR DESCRIPTION
Oops. I thought #1158 was working, but it looks like it caused some problems because I assumed that bulk-require was returning an array rather than a bunch of nested objects. Tree generated with some hacky code like:

```javascript
const f = (name) => {
  const p = name.replace(__dirname, '.')
  return `require('${p}')`
}

const x = require('bulk-require')(__dirname, ['**/!(index).js'], { require: f })
const json = JSON.stringify(x, null, 2).replace(/"require/g, 'require').replace(/\)"/g, ')')
console.log(json)
```