### PR TITLE
Add context menu option to open image in browser

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -16,7 +16,7 @@ function setupContextMenuAndSpellCheck (config, { navigate, get }) {
 
   const contextMenuBuilder = new ContextMenuBuilder(spellCheckHandler, null, true, (menu, menuInfo) => {
     const ddg = new MenuItem({
-      label: 'Search with DuckDuckGo',
+      label: 'Search With DuckDuckGo',
       click: () => {
         const url = `https://duckduckgo.com/?q=${encodeURIComponent(menuInfo.selectionText)}`
         shell.openExternal(url)
@@ -96,7 +96,7 @@ function setupContextMenuAndSpellCheck (config, { navigate, get }) {
         })
         menu.append(copyEmbed)
         const openImageInBrowser = new MenuItem({
-          label: 'Open Image with Browser',
+          label: 'Open Image With Browser',
           click: () => {
             const host = config.ws.host === '::' ? 'localhost' : config.ws.host
             const blobKey = encodeURIComponent(extractedRef)

--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -95,6 +95,16 @@ function setupContextMenuAndSpellCheck (config, { navigate, get }) {
           }
         })
         menu.append(copyEmbed)
+        const openImageInBrowser = new MenuItem({
+          label: 'Open Image with Browser',
+          click: () => {
+            const host = config.ws.host === '::' ? 'localhost' : config.ws.host
+            const blobKey = encodeURIComponent(extractedRef)
+            const url = `http://${host}:${config.ws.port}/blobs/get/${blobKey}`
+            shell.openExternal(url)
+          }
+        })
+        menu.append(openImageInBrowser)
       }
     }
 


### PR DESCRIPTION
This finally unblocks https://github.com/ssbc/ssb-markdown/pull/29 so that our Markdown doesn't have to auto-linkify images. When a user right-clicks an image it will give them the option "Open Image with Browser", which means we'll *finally* be able to add images that link to things other than the image itself (e.g. YouTube screenshot that links to the video URL).