### PR TITLE
allow "Copy Message Text" on gatherings

### DIFF
--- a/lib/context-menu-and-spellcheck.js
+++ b/lib/context-menu-and-spellcheck.js
@@ -6,7 +6,7 @@ const ref = require('ssb-ref')
 let navigateHandler = null
 module.exports = setupContextMenuAndSpellCheck
 
-function setupContextMenuAndSpellCheck (config, { navigate, get }) {
+function setupContextMenuAndSpellCheck (config, { navigate, getMessageText }) {
   navigateHandler = navigate
   const spellCheckHandler = new SpellCheckHandler()
   spellCheckHandler.attachToInput()
@@ -149,9 +149,9 @@ function setupContextMenuAndSpellCheck (config, { navigate, get }) {
         menu.append(new MenuItem({
           label: 'Copy Message Text',
           click: function () {
-            get(element.msg.key, (err, value) => {
-              if (!err && value.content && value.content.text) {
-                clipboard.writeText(value.content.text)
+            getMessageText(element.msg.key, (err, value) => {
+              if (!err) {
+                clipboard.writeText(value)
               } else {
                 showDialog({
                   type: 'error',

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -45,6 +45,7 @@ module.exports = function (config) {
     'app.fullscreen': 'first',
     'app.sync.externalHandler': 'first',
     'app.html.progressNotifier': 'first',
+    'about.async.latestValues': 'first',
     'profile.sheet.edit': 'first',
     'profile.html.preview': 'first',
     'app.navigate': 'first',
@@ -56,7 +57,7 @@ module.exports = function (config) {
   }))
 
   const i18n = api.intl.sync.i18n
-  setupContextMenuAndSpellCheck(api.config.sync.load(), { navigate, get: api.sbot.async.get })
+  setupContextMenuAndSpellCheck(api.config.sync.load(), { navigate, getMessageText })
 
   const id = api.keys.sync.id()
   const latestUpdate = LatestUpdate()
@@ -422,6 +423,21 @@ module.exports = function (config) {
   function selected (view) {
     return computed([views.currentView, view], (currentView, view) => {
       return currentView === view
+    })
+  }
+
+  function getMessageText (id, cb) {
+    api.sbot.async.get(id, (err, value) => {
+      if (err) return cb(err)
+      if (value.content.type === 'gathering') {
+        api.about.async.latestValues(id, ['title', 'description'], (err, values) => {
+          if (err) return cb(err)
+          var text = `# ${values.title}\n\n${values.description}`
+          cb(null, text)
+        })
+      } else {
+        cb(null, value.content.text)
+      }
     })
   }
 }


### PR DESCRIPTION
**Problem:** right-clicking on a gathering and selecting "Copy Message Text" always throws the error _Could not get message text._

This is because the existing code assumes that all messages with message content store this on the message as `text` but for gatherings, this is done with about messages.
 
---

The PR **refactors the `getMessageText` function out of the context menu** and **adds a handler for the weird gatherings case** to look up the message title and description through _about_.