### PR TITLE
fix showing gatherings in feed when first created

### DIFF
--- a/lib/plugins/gatherings.js
+++ b/lib/plugins/gatherings.js
@@ -19,7 +19,7 @@ exports.init = function (ssb) {
       return pull(
         ssb.messagesByType({ type: 'gathering', live: true, old: false }),
         ResolveAbouts({ ssb }),
-        ApplyFilterResult({ ssb }),
+        ApplyFilterResult({ ssb, passThroughOwn: true }),
         pull.filter(msg => !!msg.filterResult)
       )
     },
@@ -77,10 +77,11 @@ function bumpFilter (msg) {
   }
 }
 
-function ApplyFilterResult ({ ssb }) {
+function ApplyFilterResult ({ ssb, passThroughOwn = false }) {
   return pull.asyncMap((msg, cb) => {
     const isYours = ssb.id === msg.value.author
     const recps = msg.value.content.recps
+    const passThrough = isYours && passThroughOwn
     ssb.patchwork.contacts.isFollowing({ source: ssb.id, dest: msg.value.author }, (err, followingAuthor) => {
       if (err) return cb(err)
       const attending = (msg.gathering && msg.gathering.attending) || []
@@ -91,7 +92,8 @@ function ApplyFilterResult ({ ssb }) {
         const isAttending = Array.isArray(attending) && attending.includes(ssb.id)
         const isRecp = Array.isArray(recps) && recps.includes(ssb.id)
         const hasTitle = !!msg.gathering.title
-        if ((followingAttending.length || followingAuthor || isYours || isAttending || isRecp) && hasTitle) {
+        const isVisible = passThrough || hasTitle
+        if ((followingAttending.length || followingAuthor || isYours || isAttending || isRecp) && isVisible) {
           msg.filterResult = {
             followingAttending,
             followingAuthor,


### PR DESCRIPTION
**Problem:** When you first create a gathering, it doesn't display in the gatherings feed. You have to reload patchwork before it does.

This is because the handler that sends the realtime notification to update the gatherings page is checking to see if the gathering has valid details before displaying it, but due to a race condition, the details about message has not yet been indexed, so the post gets ignored.

**The PR fixes this by bypassing this check for new gatherings created by the current user.**