### PR TITLE
Fix URI decode error breaking messages

### DIFF
--- a/lib/catch-links.js
+++ b/lib/catch-links.js
@@ -16,10 +16,12 @@ module.exports = function (root, cb) {
 
     let href = anchor.getAttribute('href')
 
-    try {
-      href = decodeURIComponent(href)
-    } catch (e) {
-      // Safely ignore error because href isn't URI-encoded.
+    if (href.startsWith('#')) {
+      try {
+        href = decodeURIComponent(href)
+      } catch (e) {
+        // Safely ignore error because href isn't URI-encoded.
+      }
     }
 
     if (href) {


### PR DESCRIPTION
This was meant to resolve an issue with URI-encoded emoji but actually breaks a few messages. :( This fix seems to be working, hoping to get this in 3.16.1.