### PR TITLE
Upgrade dev deps, fix startsWith bug

### DIFF
--- a/lib/catch-links.js
+++ b/lib/catch-links.js
@@ -16,7 +16,7 @@ module.exports = function (root, cb) {
 
     let href = anchor.getAttribute('href')
 
-    if (href.startsWith('#')) {
+    if (typeof href === 'string' && href.startsWith('#')) {
       try {
         href = decodeURIComponent(href)
       } catch (e) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "7zip-bin": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-4.1.0.tgz",
-      "integrity": "sha512-AsnBZN3a8/JcNt+KPkGGODaA4c7l3W5+WpeKgGSbstSLxqWtTXqd1ieJGBQ8IFCtRg8DmmKUcSkIkUc0A4p3YA==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.0.3.tgz",
+      "integrity": "sha512-GLyWIFBbGvpKPGo55JyRZAo4lVbnBiD52cKlw/0Vt+wnmKvWJkpZvsjVoaIolyBXDeAQKSicRtqFNPem9w0WYA==",
       "dev": true
     },
     "@aabuhijleh/electron-remote": {
@@ -84,6 +84,16 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@develar/schema-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.1.0.tgz",
+      "integrity": "sha512-qjCqB4ctMig9Gz5bd6lkdFr3bO6arOdQqptdBSpF1ZpCnjofieCciEzkoS9ujY9cMGyllYSCSmBJ3x9OKHXzoA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0"
       }
     },
     "@felixrieseberg/spellchecker": {
@@ -296,41 +306,39 @@
       }
     },
     "app-builder-bin": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-2.7.1.tgz",
-      "integrity": "sha512-ubIBeiL9XysjMW4HETBKxj3DC8ika6dGyC0vftPc0kZwGh1iXQ5bycsjoAqY/3t3BBEEIg0VruicvBaUl1pOSQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-3.4.3.tgz",
+      "integrity": "sha512-qMhayIwi3juerQEVJMQ76trObEbfQT0nhUdxZz9a26/3NLT3pE6awmQ8S1cEnrGugaaM5gYqR8OElcDezfmEsg==",
       "dev": true
     },
     "app-builder-lib": {
-      "version": "20.44.4",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.44.4.tgz",
-      "integrity": "sha512-1K1xfrhyqDgnibwyuYMgvfwGilGLMF31YwOUJ8IXreyjRef9lUjWW+BZuBXqk4Uqd0C0EYPjhofgpuN0WoAQ+A==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-21.2.0.tgz",
+      "integrity": "sha512-aOX/nv77/Bti6NymJDg7p9T067xD8m1ipIEJR7B4Mm1GsJWpMm9PZdXtCRiMNRjHtQS5KIljT0g17781y6qn5A==",
       "dev": true,
       "requires": {
-        "7zip-bin": "~4.1.0",
-        "app-builder-bin": "2.7.1",
+        "7zip-bin": "~5.0.3",
+        "@develar/schema-utils": "~2.1.0",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "10.1.2",
-        "builder-util-runtime": "8.2.5",
+        "builder-util": "21.2.0",
+        "builder-util-runtime": "8.3.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.1.1",
         "ejs": "^2.6.2",
-        "electron-osx-sign": "0.4.11",
-        "electron-publish": "20.44.4",
-        "fs-extra-p": "^8.0.2",
+        "electron-publish": "21.2.0",
+        "fs-extra": "^8.1.0",
         "hosted-git-info": "^2.7.1",
         "is-ci": "^2.0.0",
-        "isbinaryfile": "^4.0.1",
+        "isbinaryfile": "^4.0.2",
         "js-yaml": "^3.13.1",
         "lazy-val": "^1.0.4",
         "minimatch": "^3.0.4",
         "normalize-package-data": "^2.5.0",
-        "plist": "^3.0.1",
-        "read-config-file": "3.2.2",
-        "sanitize-filename": "^1.6.1",
-        "semver": "^6.1.1",
-        "temp-file": "^3.3.3"
+        "read-config-file": "5.0.0",
+        "sanitize-filename": "^1.6.2",
+        "semver": "^6.3.0",
+        "temp-file": "^3.3.4"
       },
       "dependencies": {
         "debug": {
@@ -341,6 +349,23 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -878,12 +903,6 @@
         }
       }
     },
-    "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
-    },
     "base64-url": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.2.1.tgz",
@@ -1098,32 +1117,10 @@
       "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.1.tgz",
       "integrity": "sha1-ewl1dPjj6tYG+0Zk5krf3aKYGpM="
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1131,24 +1128,24 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "builder-util": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-10.1.2.tgz",
-      "integrity": "sha512-LQMh36Cg0r4ZfKqNlaUclndS/IXxZ3OdCgmXvw1vdP3QwYT2NkyE7LfMikAFIHpXOs6zsVH+iW+Fe/AX1jfFag==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-21.2.0.tgz",
+      "integrity": "sha512-Nd6CUb6YgDY8EXAXEIegx+1kzKqyFQ5ZM5BoYkeunAlwz/zDJoH1UCyULjoS5wQe5czNClFQy07zz2bzYD0Z4A==",
       "dev": true,
       "requires": {
-        "7zip-bin": "~4.1.0",
+        "7zip-bin": "~5.0.3",
         "@types/debug": "^4.1.4",
-        "app-builder-bin": "2.7.1",
+        "app-builder-bin": "3.4.3",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "^8.2.5",
+        "builder-util-runtime": "8.3.0",
         "chalk": "^2.4.2",
         "debug": "^4.1.1",
-        "fs-extra-p": "^8.0.2",
+        "fs-extra": "^8.1.0",
         "is-ci": "^2.0.0",
         "js-yaml": "^3.13.1",
-        "source-map-support": "^0.5.12",
+        "source-map-support": "^0.5.13",
         "stat-mode": "^0.3.0",
-        "temp-file": "^3.3.3"
+        "temp-file": "^3.3.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1186,6 +1183,23 @@
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -1220,14 +1234,12 @@
       }
     },
     "builder-util-runtime": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.2.5.tgz",
-      "integrity": "sha512-YILT+YUlxrE3yNB6mDC1tF+Q24mr1LSYdjP5U861jbBeDZfvy1/VPDzW3boMVrDtzYnDnvkYrzLJnoh6TXA75w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.3.0.tgz",
+      "integrity": "sha512-CSOdsYqf4RXIHh1HANPbrZHlZ9JQJXSuDDloblZPcWQVN62inyYoTQuSmY3KrgefME2Sv3Kn2MxHvbGQHRf8Iw==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "^1.0.9",
         "debug": "^4.1.1",
-        "fs-extra-p": "^8.0.2",
         "sax": "^1.2.4"
       },
       "dependencies": {
@@ -2061,19 +2073,46 @@
       "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo="
     },
     "dmg-builder": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-6.7.2.tgz",
-      "integrity": "sha512-xfYOwhHjOSOIqkk8A0h8zcaio/WyzrAWpMTu9hzV3Z5PI4tOG0Pq6a9Lh/mHr1r3bydif8R21qGvKU1Re9CpUg==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-21.2.0.tgz",
+      "integrity": "sha512-9cJEclnGy7EyKFCoHDYDf54pub/t92CQapyiUxU0w9Bj2vUvfoDagP1PMiX4XD5rPp96141h9A+QN0OB4VgvQg==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "~20.44.4",
+        "app-builder-lib": "~21.2.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "~10.1.2",
-        "fs-extra-p": "^8.0.2",
-        "iconv-lite": "^0.4.24",
+        "builder-util": "~21.2.0",
+        "fs-extra": "^8.1.0",
+        "iconv-lite": "^0.5.0",
         "js-yaml": "^3.13.1",
-        "parse-color": "^1.0.0",
-        "sanitize-filename": "^1.6.1"
+        "sanitize-filename": "^1.6.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
+        },
+        "iconv-lite": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "doctrine": {
@@ -2095,15 +2134,15 @@
       }
     },
     "dotenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+      "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==",
       "dev": true
     },
     "dotenv-expand": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
-      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
       "dev": true
     },
     "duplexer2": {
@@ -2178,24 +2217,24 @@
       }
     },
     "electron-builder": {
-      "version": "20.44.4",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.44.4.tgz",
-      "integrity": "sha512-H8zzP01albkKh2Ec1zc0A7RGriUkHb5M99NJskaYtgKtGATTAGH+r9OIWVk5Hk9c1dLMVudbqEeaSlygMF2asw==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-21.2.0.tgz",
+      "integrity": "sha512-x8EXrqFbAb2L3N22YlGar3dGh8vwptbB3ovo3OF6K7NTpcsmM2zEoJv7GhFyX73rNzSG2HaWpXwGAtOp2JWiEw==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "20.44.4",
+        "app-builder-lib": "21.2.0",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "10.1.2",
-        "builder-util-runtime": "8.2.5",
+        "builder-util": "21.2.0",
+        "builder-util-runtime": "8.3.0",
         "chalk": "^2.4.2",
-        "dmg-builder": "6.7.2",
-        "fs-extra-p": "^8.0.2",
+        "dmg-builder": "21.2.0",
+        "fs-extra": "^8.1.0",
         "is-ci": "^2.0.0",
         "lazy-val": "^1.0.4",
-        "read-config-file": "3.2.2",
-        "sanitize-filename": "^1.6.1",
-        "update-notifier": "^3.0.0",
-        "yargs": "^13.2.4"
+        "read-config-file": "5.0.0",
+        "sanitize-filename": "^1.6.2",
+        "update-notifier": "^3.0.1",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2222,6 +2261,23 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "supports-color": {
@@ -2280,48 +2336,17 @@
         }
       }
     },
-    "electron-osx-sign": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.11.tgz",
-      "integrity": "sha512-VVd40nrnVqymvFrY9ZkOYgHJOvexHHYTR3di/SN+mjJ0OWhR1I8BRVj3U+Yamw6hnkZZNKZp52rqL5EFAAPFkQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.0",
-        "compare-version": "^0.1.2",
-        "debug": "^2.6.8",
-        "isbinaryfile": "^3.0.2",
-        "minimist": "^1.2.0",
-        "plist": "^3.0.1"
-      },
-      "dependencies": {
-        "isbinaryfile": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.3.tgz",
-          "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
-          "dev": true,
-          "requires": {
-            "buffer-alloc": "^1.2.0"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "electron-publish": {
-      "version": "20.44.4",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.44.4.tgz",
-      "integrity": "sha512-50NzsKOnNqOpGJzPl04vMyitdguUvp15FWKWtu4KISsHfgdLMWGgxHGZwfMphc/vf364zXvPHsYQza3MASgaEQ==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-21.2.0.tgz",
+      "integrity": "sha512-mWavuoWJe87iaeKd0I24dNWIaR+0yRzshjNVqGyK019H766fsPWl3caQJnVKFaEyrZRP397v4JZVG0e7s16AxA==",
       "dev": true,
       "requires": {
         "bluebird-lst": "^1.0.9",
-        "builder-util": "~10.1.2",
-        "builder-util-runtime": "^8.2.5",
+        "builder-util": "~21.2.0",
+        "builder-util-runtime": "8.3.0",
         "chalk": "^2.4.2",
-        "fs-extra-p": "^8.0.2",
+        "fs-extra": "^8.1.0",
         "lazy-val": "^1.0.4",
         "mime": "^2.4.4"
       },
@@ -2350,6 +2375,23 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
           "dev": true
         },
         "supports-color": {
@@ -2818,15 +2860,15 @@
       }
     },
     "eslint-config-standard": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.0.0.tgz",
-      "integrity": "sha512-bV6e2LFvJEetrLjVAy4KWPOUsIhPWr040c649MigTPR6yUtaGuOt6CEAyNeez2lRiC+2+vjGWa02byjs25EB3A==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.0.1.tgz",
+      "integrity": "sha512-1RWsAKTDTZgA8bIM6PSC9aTGDAUlKqNkYNJlTZ5xYD/HYkIM6GlcefFvgcJ8xi0SWG5203rttKYX28zW+rKNOg==",
       "dev": true
     },
     "eslint-config-standard-jsx": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.0.0.tgz",
-      "integrity": "sha512-Abs/WP+638KfkHI1J961yAztpMhYFvEMTqD4GMUZObAO9yOmLaQZlJY6xke1ty1+zhY4G58AuvHo3ht6avAEVQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.0.1.tgz",
+      "integrity": "sha512-SDnpVLSzTcT0eLNTG7s8ffRi3WadBBpw+pFsiBj4BcrHOFOga9O/7mjtNRyPgetmsiDPWGxsiS4UdJLZhaIukA==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -3313,9 +3355,9 @@
       }
     },
     "figures": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
-      "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -3590,35 +3632,6 @@
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
-      }
-    },
-    "fs-extra-p": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-8.1.0.tgz",
-      "integrity": "sha512-sCLpU5kk5CvrWZvFM9dUlqPgHrE02AEt6XYzF7kDscr5COc7DHfhNfODTXt0bkVNmt5DkvU2uJSYjorxY3bRKA==",
-      "dev": true,
-      "requires": {
-        "bluebird-lst": "^1.0.9",
-        "fs-extra": "^8.1.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
-        }
       }
     },
     "fs.realpath": {
@@ -4668,39 +4681,36 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.1.tgz",
-      "integrity": "sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^4.2.1",
+        "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
-        "cli-cursor": "^3.1.0",
+        "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^3.0.0",
-        "lodash": "^4.17.15",
-        "mute-stream": "0.0.8",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^4.1.0",
+        "string-width": "^2.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-escapes": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
-          "integrity": "sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.5.2"
-          }
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
         },
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "ansi-styles": {
@@ -4724,19 +4734,13 @@
           }
         },
         "cli-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^3.1.0"
+            "restore-cursor": "^2.0.0"
           }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -4745,27 +4749,27 @@
           "dev": true
         },
         "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "onetime": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "^2.1.0"
+            "mimic-fn": "^1.0.0"
           }
         },
         "restore-cursor": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
-            "onetime": "^5.1.0",
+            "onetime": "^2.0.0",
             "signal-exit": "^3.0.2"
           }
         },
@@ -4779,14 +4783,24 @@
           }
         },
         "string-width": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.1.0.tgz",
-          "integrity": "sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^5.2.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
           }
         },
         "strip-ansi": {
@@ -4796,6 +4810,14 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -4806,12 +4828,6 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "type-fest": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-          "integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
-          "dev": true
         }
       }
     },
@@ -5964,9 +5980,9 @@
       }
     },
     "mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "mimic-response": {
@@ -6145,8 +6161,8 @@
       "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
     },
     "mutant": {
-      "version": "3.22.1",
-      "resolved": "github:mmckegg/mutant#e880acd7df1e14b67026d826902543ceb3556566",
+      "version": "github:mmckegg/mutant#e880acd7df1e14b67026d826902543ceb3556566",
+      "from": "github:mmckegg/mutant#intersection-binding-viewport",
       "requires": {
         "browser-split": "0.0.1",
         "source-map-support": "^0.5.9",
@@ -6201,9 +6217,9 @@
       }
     },
     "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
     "muxrpc": {
@@ -6746,23 +6762,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "parse-color": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
-      "integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
-      "dev": true,
-      "requires": {
-        "color-convert": "~0.5.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
-          "dev": true
-        }
-      }
-    },
     "parse-entities": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
@@ -7023,17 +7022,6 @@
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         }
-      }
-    },
-    "plist": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.1.tgz",
-      "integrity": "sha512-GpgvHHocGRyQm74b6FWEZZVRroHKE1I0/BTjAmySaohK+cUn+hZpbqXkc3KWgW3gQYkqcQej35FohcT0FRlkRQ==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.2.3",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "0.1.x"
       }
     },
     "plur": {
@@ -7644,42 +7632,35 @@
       "dev": true
     },
     "read-config-file": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-3.2.2.tgz",
-      "integrity": "sha512-PuFpMgZF01VB0ydH1dfitAxCP/fh+qnfbA9cYNIPoxPbz0SMngsrafCtaHDWfER7MwlDz4fmrNBhPkakxxFpTg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-5.0.0.tgz",
+      "integrity": "sha512-jIKUu+C84bfnKxyJ5j30CxCqgXWYjZLXuVE/NYlMEpeni+dhESgAeZOZd0JZbg1xTkMmnCdxksDoarkOyfEsOg==",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.2",
-        "ajv-keywords": "^3.4.0",
-        "bluebird-lst": "^1.0.7",
-        "dotenv": "^6.2.0",
-        "dotenv-expand": "^4.2.0",
-        "fs-extra-p": "^7.0.1",
-        "js-yaml": "^3.12.1",
+        "dotenv": "^8.0.0",
+        "dotenv-expand": "^5.1.0",
+        "fs-extra": "^8.1.0",
+        "js-yaml": "^3.13.1",
         "json5": "^2.1.0",
         "lazy-val": "^1.0.4"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
+            "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
         },
-        "fs-extra-p": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-7.0.1.tgz",
-          "integrity": "sha512-yhd2OV0HnHt2oitlp+X9hl2ReX4X/7kQeL7/72qzPHTZj5eUPGzAKOvEglU02Fa1OeG2rSy/aKB4WGVaLiF8tw==",
-          "dev": true,
-          "requires": {
-            "bluebird-lst": "^1.0.7",
-            "fs-extra": "^7.0.1"
-          }
+        "graceful-fs": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+          "dev": true
         },
         "json5": {
           "version": "2.1.0",
@@ -9085,8 +9066,8 @@
       }
     },
     "ssb-config": {
-      "version": "3.2.5",
-      "resolved": "github:ssbc/ssb-config#7709f306ba95ad10cc514ca091b36e6d9f09de85",
+      "version": "github:ssbc/ssb-config#7709f306ba95ad10cc514ca091b36e6d9f09de85",
+      "from": "github:ssbc/ssb-config#auto-config-incoming",
       "requires": {
         "deep-extend": "^0.6.0",
         "lodash.get": "^4.4.2",
@@ -9168,33 +9149,6 @@
         "pull-stream": "^3.5.0",
         "push-stream-to-pull-stream": "^1.0.0",
         "ssb-ref": "^2.9.1"
-      }
-    },
-    "ssb-gossip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ssb-gossip/-/ssb-gossip-1.1.0.tgz",
-      "integrity": "sha512-z4DBUtGJ+/k6z67EjavmPYAKz9BLF7zWcSDwUwLKZZT3AJp/5J6iPxHkilz2UfJ9LdGT4gF5CUe2xyIt1QFguA==",
-      "requires": {
-        "atomic-file": "^1.1.5",
-        "deep-equal": "^1.0.1",
-        "has-network": "0.0.1",
-        "ip": "^1.1.5",
-        "mdmanifest": "^1.0.8",
-        "muxrpc-validation": "^3.0.0",
-        "on-change-network": "0.0.2",
-        "on-wakeup": "^1.0.1",
-        "pull-notify": "^0.1.1",
-        "pull-ping": "^2.0.2",
-        "pull-stream": "^3.6.9",
-        "ssb-ref": "^2.13.9",
-        "statistics": "^3.3.0"
-      },
-      "dependencies": {
-        "atomic-file": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/atomic-file/-/atomic-file-1.1.5.tgz",
-          "integrity": "sha512-TG+5YFiaKQ6CZiSQsosGMJ/IJzwMZ4V/rSdEXlD6+DwKyv8OyeUcprq34kp4yuS6bfQYXhxBC2Vm8PWo+iKBGQ=="
-        }
       }
     },
     "ssb-invite": {
@@ -9526,14 +9480,14 @@
       "integrity": "sha1-6SNZipvlHmF2gsshzxsoGKRJraI="
     },
     "standard": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-14.0.0.tgz",
-      "integrity": "sha512-FNKr9wkXQYvqO1txmileQm+r3+NBJp/H+yF1x9Ak3kZgLh3xrmc5HDyiKWizMEekbffBC7yq+PuB8+GMuRp8Vg==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-14.0.2.tgz",
+      "integrity": "sha512-2Rjsc+B1zaXiQVfUlH7n+ZIrCpxxAaVEItps2lBQUQLuyCH/Vc788w6q16PMK4ezPA61jm8A1vzBnBwcokGOgQ==",
       "dev": true,
       "requires": {
         "eslint": "~6.1.0",
-        "eslint-config-standard": "~14.0.0",
-        "eslint-config-standard-jsx": "~8.0.0",
+        "eslint-config-standard": "14.0.1",
+        "eslint-config-standard-jsx": "8.0.1",
         "eslint-plugin-import": "~2.18.0",
         "eslint-plugin-node": "~9.1.0",
         "eslint-plugin-promise": "~4.2.1",
@@ -10736,18 +10690,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-      "dev": true
-    },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xmlhttprequest": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "ssb-config": "github:ssbc/ssb-config#auto-config-incoming",
     "ssb-db": "^19.3.0",
     "ssb-ebt": "^5.6.7",
-    "ssb-gossip": "^1.1.0",
     "ssb-invite": "^2.1.3",
     "ssb-keys": "^7.2.0",
     "ssb-legacy-conn": "1.0.12",
@@ -103,9 +102,9 @@
   "devDependencies": {
     "changelog-version": "^1.0.1",
     "colors": "^1.3.3",
-    "electron": "^4.2.9",
-    "electron-builder": "^20.44.4",
-    "standard": "^14.0.0"
+    "electron": "^4.0.0",
+    "electron-builder": "^21.2.0",
+    "standard": "^14.0.2"
   },
   "optionalDependencies": {
     "mouse-forward-back": "^1.0.1"


### PR DESCRIPTION
1. Simple dependency upgrade for electron-builder and standard
2. Simple bugfix for links where `href === null` (!), like the back link
3. Removed unused ssb-gossip