### PR TITLE
Add attending gatherings view

### DIFF
--- a/lib/catch-links.js
+++ b/lib/catch-links.js
@@ -16,15 +16,14 @@ module.exports = function (root, cb) {
 
     let href = anchor.getAttribute('href')
 
-    if (href.startsWith('#')) {
-      try {
-        href = decodeURIComponent(href)
-      } catch (e) {
-        // Safely ignore error because href isn't URI-encoded.
-      }
-    }
-
     if (href) {
+      if (href.startsWith('#')) {
+        try {
+          href = decodeURIComponent(href)
+        } catch (e) {
+          // Safely ignore error because href isn't URI-encoded.
+        }
+      }
       let isUrl
       let url
 

--- a/lib/depject/app/html/search.js
+++ b/lib/depject/app/html/search.js
@@ -12,7 +12,7 @@ exports.needs = nest({
 
 exports.gives = nest('app.html.search')
 
-const pages = ['/public', '/private', '/mentions', '/all', '/gatherings']
+const pages = ['/public', '/private', '/mentions', '/all', '/gatherings', '/participating', '/attending-gatherings']
 
 exports.create = function (api) {
   const i18n = api.intl.sync.i18n

--- a/lib/depject/index.js
+++ b/lib/depject/index.js
@@ -161,7 +161,8 @@ module.exports = {
           search: require('./page/html/render/search.js'),
           settings: require('./page/html/render/settings.js'),
           tag: require('./page/html/render/tag.js'),
-          'your-posts': require('./page/html/render/your-posts.js')
+          'your-posts': require('./page/html/render/your-posts.js'),
+          'attending-gatherings': require('./page/html/render/attending-gatherings.js')
         }
       }
     },

--- a/lib/depject/page/html/render/attending-gatherings.js
+++ b/lib/depject/page/html/render/attending-gatherings.js
@@ -1,0 +1,37 @@
+const { h, send } = require('mutant')
+const nest = require('depnest')
+
+exports.needs = nest({
+  'feed.html.rollup': 'first',
+  'sbot.pull.resumeStream': 'first',
+  'app.navigate': 'first',
+  'sbot.pull.stream': 'first',
+  'contact.obs.following': 'first',
+  'intl.sync.i18n': 'first'
+})
+
+exports.gives = nest('page.html.render')
+
+exports.create = function (api) {
+  const i18n = api.intl.sync.i18n
+  return nest('page.html.render', function channel (path) {
+    if (path !== '/attending-gatherings') return
+    const prepend = [
+      h('PageHeading', [
+        h('h1', [h('strong', i18n('Attending Gatherings'))]),
+        h('div.meta', [
+          h('button', { 'ev-click': send(api.app.navigate, '/gatherings') }, 'View All Gatherings')
+        ])
+      ])
+    ]
+
+    const getStream = api.sbot.pull.resumeStream((sbot, opts) => {
+      return sbot.patchwork.gatherings.roots(opts)
+    }, { limit: 40, reverse: true, onlyAttending: true })
+
+    return api.feed.html.rollup(getStream, {
+      prepend,
+      updateStream: api.sbot.pull.stream(sbot => sbot.patchwork.gatherings.latestAttending())
+    })
+  })
+}

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -229,7 +229,10 @@ module.exports = function (config) {
             [i18n('All Threads'), '/participating'],
             [i18n('Threads Started By You'), '/your-posts']
           ]),
-          [i18n('Gatherings'), '/gatherings'],
+          subMenu(i18n('Gatherings'), [
+            [i18n('All'), '/gatherings'],
+            [i18n('Attending'), '/attending-gatherings']
+          ]),
           [i18n('Tags'), `/tags/all/${encodeURIComponent(id)}`],
           [i18n('Extended Network'), '/all'],
           { separator: true },

--- a/lib/plugins/gatherings.js
+++ b/lib/plugins/gatherings.js
@@ -6,10 +6,13 @@ const threadSummary = require('../thread-summary')
 const ResolveAbouts = require('../resolve-abouts')
 const Paramap = require('pull-paramap')
 const FilterBlocked = require('../filter-blocked')
+const LookupRoots = require('../lookup-roots')
+
 const async = require('async')
 
 exports.manifest = {
   latest: 'source',
+  latestAttending: 'source',
   roots: 'source'
 }
 
@@ -23,7 +26,18 @@ exports.init = function (ssb) {
         pull.filter(msg => !!msg.filterResult)
       )
     },
-    roots: function ({ reverse, limit, resume }) {
+    latestAttending: function () {
+      return pull(
+        ssb.query.read({
+          query: [{ $filter: { value: { content: { type: 'about', attendee: { link: ssb.id } } } } }]
+        }),
+        LookupRoots({ ssb }),
+        ResolveAbouts({ ssb }),
+        ApplyFilterResult({ ssb, passThroughOwn: true }),
+        pull.filter(msg => !!msg.filterResult)
+      )
+    },
+    roots: function ({ reverse, limit, resume, onlyAttending = false }) {
       // use resume option if specified
       const opts = { reverse, old: true, type: 'gathering', private: true }
       if (resume) {
@@ -45,7 +59,7 @@ exports.init = function (ssb) {
           ResolveAbouts({ ssb }),
 
           // FILTER GATHERINGS BASED ON ATTENDEES AND AUTHOR (and hide if no title)
-          ApplyFilterResult({ ssb }),
+          ApplyFilterResult({ ssb, onlyAttending }),
           pull.filter(msg => !!msg.filterResult),
 
           // ADD THREAD SUMMARY
@@ -77,7 +91,7 @@ function bumpFilter (msg) {
   }
 }
 
-function ApplyFilterResult ({ ssb, passThroughOwn = false }) {
+function ApplyFilterResult ({ ssb, passThroughOwn = false, onlyAttending = false }) {
   return pull.asyncMap((msg, cb) => {
     const isYours = ssb.id === msg.value.author
     const recps = msg.value.content.recps
@@ -93,14 +107,19 @@ function ApplyFilterResult ({ ssb, passThroughOwn = false }) {
         const isRecp = Array.isArray(recps) && recps.includes(ssb.id)
         const hasTitle = !!msg.gathering.title
         const isVisible = passThrough || hasTitle
-        if ((followingAttending.length || followingAuthor || isYours || isAttending || isRecp) && isVisible) {
+
+        if (onlyAttending && !isAttending && !isYours) {
+          // only wanting events we are attending, and we are not attending so don't run filters
+        } else if ((followingAttending.length || followingAuthor || isYours || isAttending || isRecp) && isVisible) {
           msg.filterResult = {
             followingAttending,
             followingAuthor,
+            isAttending,
             isYours,
             hasTitle
           }
         }
+
         cb(null, msg)
       })
     })

--- a/locales/en.json
+++ b/locales/en.json
@@ -311,5 +311,8 @@
 	"eo": "eo",
 	"zh-TW": "zh-TW",
 	"Blocking": "Blocking",
-	"Automatically delete messages from blocked authors. This is irreversible and will cause problems with clients that share the database but do not support deleted messages. Enable at your own risk!": "Automatically delete messages from blocked authors. This is irreversible and will cause problems with clients that share the database but do not support deleted messages. Enable at your own risk!"
+	"Automatically delete messages from blocked authors. This is irreversible and will cause problems with clients that share the database but do not support deleted messages. Enable at your own risk!": "Automatically delete messages from blocked authors. This is irreversible and will cause problems with clients that share the database but do not support deleted messages. Enable at your own risk!",
+	"All": "All",
+	"Attending": "Attending",
+	"Attending Gatherings": "Attending Gatherings"
 }


### PR DESCRIPTION
This PR adds a new gatherings view that only shows gatherings that you have selected "attending".

<img width="840" alt="Screen Shot 2019-08-28 at 3 16 48 PM" src="https://user-images.githubusercontent.com/66834/63823233-35274c00-c9a7-11e9-8c98-e17c33cf2bb1.png">

You access it via More > Gatherings > Attending:

<img width="738" alt="Screen Shot 2019-08-28 at 3 16 32 PM" src="https://user-images.githubusercontent.com/66834/63823252-45d7c200-c9a7-11e9-844a-6e8ed0fd1e9b.png">

Currently this view shows posts in the order the events were created. A future improvement could show the events in order of the gathering date, or ordered by when you clicked attending.
