### PR TITLE
Fix href bug causing errors for KIO

### DIFF
--- a/lib/depject/channel/html/preview.js
+++ b/lib/depject/channel/html/preview.js
@@ -28,9 +28,9 @@ exports.create = function (api) {
   return nest('channel.html.preview', function (id) {
     const yourId = api.keys.sync.id()
     const channel = api.channel.sync.normalize(id)
-    let href = '#' + channel
+    let target = '#' + channel
     try {
-      href = decodeURIComponent(href)
+      target = decodeURIComponent(target)
     } catch (e) {
       // Safely ignore because it wasn't URI-encoded. :)
     }
@@ -46,7 +46,7 @@ exports.create = function (api) {
         h('div.main', [
           h('div.title', [
             h('h1', [
-              h('a', { href, 'ev-click': () => api.app.navigate(href) }, [href])
+              h('a', { href: '#', 'ev-click': () => api.app.navigate(target) }, [target])
             ]),
             h('div.meta', [
               api.channel.html.subscribeToggle(channel)

--- a/lib/depject/profile/html/preview.js
+++ b/lib/depject/profile/html/preview.js
@@ -34,7 +34,7 @@ exports.create = function (api) {
         h('div.main', [
           h('div.title', [
             h('h1', [
-              h('a', { href: id, 'ev-click': () => api.app.navigate(id) }, [name])
+              h('a', { href: '#', 'ev-click': () => api.app.navigate(id) }, [name])
             ]),
             h('div.meta', [
               api.contact.html.followToggle(id, { block: false })


### PR DESCRIPTION
Our `<a>` elements don't actually need a `href` because we're managing the navigation with JavaScript. This may resolve #1203, which seems to be a strange bug caused by our `href` to pages that don't actually exist.

cc: @kjcole, would love if you could test whether this resolves your issue