### PR TITLE
Add cask-repair to update Homebrew cask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script: npm test && npm run dist
 after_success: - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       export GITHUB_TOKEN=$GH_TOKEN
-      cask-repair patchwork
+      cask-repair --blind-submit patchwork 
     fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
-      addons:
-        homebrew:
-          packages:
-          - vitorgalvao/tiny-scripts/cask-repair
   
     - os: linux
       language: node_js
@@ -20,6 +16,14 @@ matrix:
       language: node_js
       node_js: lts/*
       filter_secrets: false
+
+addons:
+  homebrew:
+    update: true
+    taps:
+      - vitorgalvao/tiny-scripts
+    packages:
+      - cask-repair
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_install:
 
 script: npm test && npm run dist
 
-after_success: - |
+after_success:
+  - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       export GITHUB_TOKEN=$GH_TOKEN
       cask-repair --blind-submit patchwork 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,17 @@ before_install:
         libxtst-dev
     fi
 
+  - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      brew install vitorgalvao/tiny-scripts/cask-repair
+    fi
+
 script: npm test && npm run dist
+
+after_success: - |
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      cask-repair patchwork
+    fi
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script: npm test && npm run dist
 
 after_success: - |
     if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      export GITHUB_TOKEN=$GH_TOKEN
       cask-repair patchwork
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+      addons:
+        homebrew:
+          packages:
+          - vitorgalvao/tiny-scripts/cask-repair
   
     - os: linux
       language: node_js
@@ -33,11 +37,6 @@ before_install:
         libxext-dev \
         libxkbfile-dev \
         libxtst-dev
-    fi
-
-  - |
-    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      brew install vitorgalvao/tiny-scripts/cask-repair
     fi
 
 script: npm test && npm run dist


### PR DESCRIPTION
This should run `cask-repair` after every successful CI run, which *hopefully* uses the hermes-bot account to issue pull requests.

Resolves #1127 