### PR TITLE
URL change getting-started > get-started

### DIFF
--- a/lib/depject/feed/html/follow-warning.js
+++ b/lib/depject/feed/html/follow-warning.js
@@ -29,8 +29,8 @@ exports.create = function (api) {
       h('p', explanation),
       h('p', [i18n('For help getting started, see the guide at '),
         h('a', {
-          href: 'https://scuttlebutt.nz/getting-started.html'
-        }, 'https://scuttlebutt.nz/getting-started.html')
+          href: 'https://scuttlebutt.nz/get-started'
+        }, 'https://scuttlebutt.nz/get-started')
       ])
     ]))
 


### PR DESCRIPTION
Link from message "You are not following anyone" was pointing to 404. Destination page was moved.