### PR TITLE
docs: Suggest building from source

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -57,6 +57,12 @@ With npm:
 npm install
 ```
 
+If you receive 'No native build found' errors, try instead:
+
+```shell
+npm install --build-from-source
+```
+
 With yarn:
 
 ```shell


### PR DESCRIPTION
Some platforms may require building from source as node's pre-built binarys could be incompatible.  This may fix 'No native build found' errors.

Fixes #1225 