### PR TITLE
New architectures: ia32 and arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,13 +142,6 @@
           ]
         },
         {
-          "target": "nsis",
-          "arch": [
-            "x64",
-            "ia32"
-          ]
-        },
-        {
           "target": "zip",
           "arch": [
             "x64",

--- a/package.json
+++ b/package.json
@@ -115,15 +115,15 @@
       "target": [
         {
 					"target": "AppImage",
-					"arch": ["x64", "ia32", "arm64"]
+					"arch": ["x64", "arm64"]
         },
         {
 					"target": "snap",
-					"arch": ["x64", "ia32"]
+					"arch": ["x64"]
         },
         {
 					"target": "deb",
-					"arch": ["x64", "ia32"]
+					"arch": ["x64"]
 				}
       ]
     },

--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
         "AppImage",
         "snap",
         "deb"
+      ],
+      "arch": [
+        "x64",
+        "ia32",
+        "amd64"
       ]
     },
     "deb": {
@@ -134,6 +139,21 @@
           "arch": [
             "x64",
             "ia32"
+          ]
+        },
+        {
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "ia32",
+            "arm64"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -119,11 +119,11 @@
         },
         {
 					"target": "snap",
-					"arch": ["x64", "ia32", "arm64"]
+					"arch": ["x64", "ia32"]
         },
         {
 					"target": "deb",
-					"arch": ["x64", "ia32", "arm64"]
+					"arch": ["x64", "ia32"]
 				}
       ]
     },
@@ -143,14 +143,6 @@
           "arch": [
             "x64",
             "ia32"
-          ]
-        },
-        {
-          "target": "zip",
-          "arch": [
-            "x64",
-            "ia32",
-            "arm64"
           ]
         }
       ]

--- a/package.json
+++ b/package.json
@@ -113,14 +113,18 @@
     "linux": {
       "category": "Network",
       "target": [
-        "AppImage",
-        "snap",
-        "deb"
-      ],
-      "arch": [
-        "x64",
-        "ia32",
-        "amd64"
+        {
+					"target": "AppImage",
+					"arch": ["x64", "ia32", "arm64"]
+        },
+        {
+					"target": "snap",
+					"arch": ["x64", "ia32", "arm64"]
+        },
+        {
+					"target": "deb",
+					"arch": ["x64", "ia32", "arm64"]
+				}
       ]
     },
     "deb": {


### PR DESCRIPTION
New architectures: ia32 and arm64 for both Linux and Windows.

Also added a new build target for windows: "zip" which makes it easier to work with package managers.