### PR TITLE
update ssb-conn to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3550,10 +3550,10 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "has-network": {
+    "has-network2": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/has-network/-/has-network-0.0.1.tgz",
-      "integrity": "sha1-Pup7RMqpYBeXEkvouonSKMQQFJk="
+      "resolved": "https://registry.npmjs.org/has-network2/-/has-network2-0.0.1.tgz",
+      "integrity": "sha512-cpqaHIBwSKOhHzpWPXS2FnOzN6ekF238MxonA1CWZNx7UivVlq3GF+GqS6gXbvDwMYoaxXM+8el7tP8uFSrjsQ=="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -5447,10 +5447,10 @@
         }
       }
     },
-    "on-change-network": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/on-change-network/-/on-change-network-0.0.2.tgz",
-      "integrity": "sha1-2XcklHf5FyaUnYDoI0batu9FIWs="
+    "on-change-network-strict": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/on-change-network-strict/-/on-change-network-strict-1.0.0.tgz",
+      "integrity": "sha512-ldHCpTJWgr5KUJy3/TVoSGNwBUA8BP9UFmd0iQqe4aGaXY4PJyzQPiVBIo8VBSlSoKyaJY3vcpW0hixZb6gPaA=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -5962,9 +5962,9 @@
       }
     },
     "promisify-tuple": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/promisify-tuple/-/promisify-tuple-1.0.0.tgz",
-      "integrity": "sha512-cLx3LIS6pjWJym+M2TWCc5Mvt6LFaZakGBaRQWpOQkrcobJ7PHFX7m+VXnbb9Ha7n4SULB9ajulWvasSdi5JHw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promisify-tuple/-/promisify-tuple-1.0.1.tgz",
+      "integrity": "sha512-st4Q1R6oAr8hzt1hj3uCYv87Pc5wtDkoq7ZqxWri2xR3x5Zvx7syH2DR4fgknVhMsZ6GV+kxEmhn2tVnwFMmJw=="
     },
     "promisize": {
       "version": "1.1.2",
@@ -6216,9 +6216,9 @@
       "integrity": "sha1-GdRb6PqmFfpVbxSpb9czRiw3+6M="
     },
     "pull-ping": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.2.tgz",
-      "integrity": "sha1-e8SjQBZ9rYj2gqGWxjSFc1x6CJQ=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pull-ping/-/pull-ping-2.0.3.tgz",
+      "integrity": "sha512-nbY4yHnMesJBrvkbhMim4VXUC9k1VCkgrkQu49pf8mxFbmb/U2KQrsuePvSmLjRL+VgkBVRSUXUoOY7DtSvhKw==",
       "requires": {
         "pull-pushable": "^2.0.0",
         "pull-stream": "^3.4.5",
@@ -7058,11 +7058,6 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
-        "mime": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -7485,14 +7480,14 @@
       }
     },
     "ssb-conn": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.10.3.tgz",
-      "integrity": "sha512-H6ybgqSYk+IeuqFBPurIdGUM4bJy8nBUh88aQ3uc26m12x9ylqq3jO34Rf1axW/CYPSpcndBqDNA+fe1C7bJjA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.12.0.tgz",
+      "integrity": "sha512-PQLeTw8/Nuj77Lp8b9c392F4jWPzt2+NxcSiX+BGO7RIA1A8AvJTFBvkxe0A/MaBVltVV4iTLTILA59BI7qn+Q==",
       "requires": {
         "debug": "~4.1.1",
-        "has-network": "0.0.1",
+        "has-network2": "0.0.1",
         "ip": "^1.1.5",
-        "on-change-network": "0.0.2",
+        "on-change-network-strict": "1.0.0",
         "on-wakeup": "^1.0.1",
         "pull-notify": "^0.1.1",
         "pull-pause": "~0.0.2",
@@ -7500,8 +7495,8 @@
         "pull-stream": "^3.6.9",
         "secret-stack-decorators": "1.0.0",
         "ssb-conn-db": "~0.2.1",
-        "ssb-conn-hub": "~0.2.3",
-        "ssb-conn-query": "~0.4.1",
+        "ssb-conn-hub": "~0.2.7",
+        "ssb-conn-query": "~0.4.4",
         "ssb-conn-staging": "~0.1.0",
         "ssb-ref": "^2.13.9",
         "ssb-typescript": "^1.4.0",
@@ -7557,9 +7552,9 @@
       }
     },
     "ssb-conn-hub": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.4.tgz",
-      "integrity": "sha512-qcWOs2A9cpFBz289CAp9S30Df9+64dBmb/SsfEOOJZPwc6N1YMhpUlRxRYmn/MLNXm+mSLafiLz7lqgxMdzcLw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/ssb-conn-hub/-/ssb-conn-hub-0.2.7.tgz",
+      "integrity": "sha512-fvX7HK44V65C8uMQhTK9B4SHZE7K5P0AU/cHVuDciKPNagEFV0QHKk//JnrrMKHKKvz1msKUxhA0S0iH0S4gqQ==",
       "requires": {
         "debug": "^4.1.1",
         "ip": "^1.1.5",
@@ -7584,33 +7579,16 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "multiserver": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/multiserver/-/multiserver-3.4.0.tgz",
-          "integrity": "sha512-HSGnZBXDM9e8gi3YyhObwiDYP3BFeL+TV22H1dAReigHHMc52IDBsz9N1OR72OKxCd7SMD+gKBpVJbJohhb3og==",
-          "requires": {
-            "debug": "^4.1.1",
-            "multicb": "^1.2.2",
-            "multiserver-scopes": "^1.0.0",
-            "pull-cat": "~1.1.5",
-            "pull-stream": "^3.6.1",
-            "pull-ws": "^3.3.0",
-            "secret-handshake": "^1.1.16",
-            "separator-escape": "0.0.0",
-            "socks": "^2.2.3",
-            "stream-to-pull-stream": "^1.7.2"
-          }
         }
       }
     },
     "ssb-conn-query": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.1.tgz",
-      "integrity": "sha512-obGIHTyF2tnnKOALzUEkhlLWoAMHL2hvB6E/EEupMaRoxkmdj6BxjUWMOKYJvdr9XfCJYB+bVvpzfslwOsayYg==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.4.tgz",
+      "integrity": "sha512-FeHwQwec24RyEFImETEnP5Qdzg3IPOhEDNloJ9PqsZfd1c3fCoY0aunJz6Z3OgkrGIVSPzS4eze6iXx+ns+WIw==",
       "requires": {
         "ssb-conn-db": "~0.2.1",
-        "ssb-conn-hub": "~0.2.3",
+        "ssb-conn-hub": "~0.2.7",
         "ssb-conn-staging": "~0.1.0"
       }
     },
@@ -7879,9 +7857,9 @@
       }
     },
     "ssb-room": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.0.0.tgz",
-      "integrity": "sha512-yx38+iyfOhXKPnoexmKW2cTK717cODNiiPPWM+ZZMmLcmJWjhPN6oY8KT3O0u/YnHgK6jCXEm4w4vRQPSvHWew==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ssb-room/-/ssb-room-1.1.3.tgz",
+      "integrity": "sha512-XvmmHVFqXauZiHiCAayGqEMK8K7AUtfuHLCqXxzJwllrYWmDa2n1+TPlsD47pgsGTkdwCpcMGvN8iLa2qE0Efw==",
       "requires": {
         "body-parser": "^1.16.0",
         "debug": "~4.1.1",
@@ -7896,7 +7874,7 @@
         "ssb-caps": "~1.1.0",
         "ssb-client": "~4.7.8",
         "ssb-config": "~3.3.2",
-        "ssb-conn": "~0.10.0",
+        "ssb-conn": ">=0.11.0",
         "ssb-logging": "~1.0.0",
         "ssb-master": "~1.0.3",
         "ssb-ref": "~2.13.9"
@@ -7935,13 +7913,13 @@
           }
         },
         "ssb-config": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.2.tgz",
-          "integrity": "sha512-EUOp8QbFgCqy6RzNgLqoTqI+jtpBi3AHUwAymR3jHGbgc3DqCMnvGCHt7My8m15LA88oyeDjrzNNJsLfbVyTZQ==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.3.3.tgz",
+          "integrity": "sha512-5dcFuYrUqyELNHzX3fOcgF/SRdjVWjkXxgq5+D+bt7KUy1YCCAEiB1VkQfhwWeDblYQCaXSE6rhuWO9JMTkJSg==",
           "requires": {
             "deep-extend": "^0.6.0",
             "lodash.get": "^4.4.2",
-            "non-private-ip": "^1.2.1",
+            "non-private-ip": "^1.4.4",
             "os-homedir": "^1.0.1",
             "rc": "^1.1.6",
             "ssb-caps": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ssb-blobs": "^1.2.2",
     "ssb-client": "^4.7.9",
     "ssb-config": "^3.4.3",
-    "ssb-conn": "~0.10.3",
+    "ssb-conn": "~0.12.0",
     "ssb-db": "^19.3.0",
     "ssb-ebt": "^5.6.7",
     "ssb-friends": "^4.1.4",
@@ -88,7 +88,7 @@
     "ssb-query": "^2.4.3",
     "ssb-ref": "^2.13.9",
     "ssb-replicate": "^1.3.1",
-    "ssb-room": "^1.0.0",
+    "ssb-room": "^1.1.3",
     "ssb-search": "^1.2.1",
     "ssb-sort": "^1.1.3",
     "ssb-suggest": "^1.0.4",
@@ -114,17 +114,24 @@
       "category": "Network",
       "target": [
         {
-					"target": "AppImage",
-					"arch": ["x64", "arm64"]
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         },
         {
-					"target": "snap",
-					"arch": ["x64"]
+          "target": "snap",
+          "arch": [
+            "x64"
+          ]
         },
         {
-					"target": "deb",
-					"arch": ["x64"]
-				}
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
       ]
     },
     "deb": {


### PR DESCRIPTION
Updating ssb-conn from 0.11.3 to 0.12 [tweaks the scheduler](https://github.com/staltz/ssb-conn/compare/014c407cdaa722e9a04906a1678b463dc06356b6..v0.12.0#diff-0b5f8eafe190c56c8bc6564584ca24d6) with a few improvements:

- Connect to slightly less staged friends
- Connect to less rooms (from 10 to 5)
- Treat rooms as non-syncable peers

Note though that Patchwork was using ssb-conn 0.10.3 so it will also get these long-due updates:

- Dont use deprecated ssbRef.parseAddress in scheduler 
- `has-network` => `has-network2` ([removes some weird unnecessary module.exports hacks](https://github.com/staltz/has-network2/commit/0da8a9157092ea09d12122a6dc1ea18debbb2659))
- `on-change-network` => `on-change-network-strict` ([uses JavaScript "use strict"](https://github.com/staltz/on-change-network-strict/commit/261163acdf330d828db3f57429e5d23e2a6102ae))
- Scheduler: update grace period for connecting peers
- Remove hacks for DHT addresses in the (legacy compatibility) gossip plugin 

Other transitive dependencies updated by this PR:

- `promisify-tuple`: 1.0.0 => 1.0.1
- `pull-ping`: 2.0.2 => 2.0.3
- `ssb-conn-hub`: 0.2.4 => 0.2.7
  - make sure all the rpc.close calls have callbacks 
  - improve inferredType for DHT peers 
  - remove hacks related to DHT addresses
- `ssb-conn-query`: 0.4.1 => 0.4.4
- `ssb-room`: 1.0.0 => 1.1.3
  - client plugin: gracefully close RPC connection with server 

**This PR was tested in production locally on my laptop, I ran Patchwork with these updates and it worked fine.**