### PR TITLE
update ssb-conn to 0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7480,9 +7480,9 @@
       }
     },
     "ssb-conn": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.12.0.tgz",
-      "integrity": "sha512-PQLeTw8/Nuj77Lp8b9c392F4jWPzt2+NxcSiX+BGO7RIA1A8AvJTFBvkxe0A/MaBVltVV4iTLTILA59BI7qn+Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.15.1.tgz",
+      "integrity": "sha512-BmGT6QMUwNmI/AiC9jROzg5aN3DizfmUvG3xXkffp3EnhCW7CKW22O7mv3WrB2wdNvLw/rK+suUJdej6NU68EQ==",
       "requires": {
         "debug": "~4.1.1",
         "has-network2": "0.0.1",
@@ -7491,15 +7491,15 @@
         "on-wakeup": "^1.0.1",
         "pull-notify": "^0.1.1",
         "pull-pause": "~0.0.2",
-        "pull-ping": "^2.0.2",
-        "pull-stream": "^3.6.9",
+        "pull-ping": "^2.0.3",
+        "pull-stream": "^3.6.14",
         "secret-stack-decorators": "1.0.0",
-        "ssb-conn-db": "~0.2.1",
+        "ssb-conn-db": "~0.3.0",
         "ssb-conn-hub": "~0.2.7",
-        "ssb-conn-query": "~0.4.4",
+        "ssb-conn-query": "~0.4.5",
         "ssb-conn-staging": "~0.1.0",
         "ssb-ref": "^2.13.9",
-        "ssb-typescript": "^1.4.0",
+        "ssb-typescript": "^1.5.0",
         "statistics": "^3.3.0",
         "zii": "~1.1.0"
       },
@@ -7520,9 +7520,9 @@
       }
     },
     "ssb-conn-db": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.2.1.tgz",
-      "integrity": "sha512-ZcqB6pXyu20UmQ+3QPr8mY1+TAdQfQv20qjkf0wqm9LB1GRkYfKLm2O7Nc2DpLs1SOsWuFXfO8vgXjEAsDBOQQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.1.tgz",
+      "integrity": "sha512-1cCbfaVDow50FNx+0V1hGIJsSy1RIn10J16D/gBlWRxB1ddGr5v6TCtFyc6Y+J/6Gnx+BPTKwqd9vTJ1ow6RCA==",
       "requires": {
         "atomic-file": "^1.1.5",
         "debug": "~4.1.1",
@@ -7583,11 +7583,11 @@
       }
     },
     "ssb-conn-query": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.4.tgz",
-      "integrity": "sha512-FeHwQwec24RyEFImETEnP5Qdzg3IPOhEDNloJ9PqsZfd1c3fCoY0aunJz6Z3OgkrGIVSPzS4eze6iXx+ns+WIw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-conn-query/-/ssb-conn-query-0.4.5.tgz",
+      "integrity": "sha512-1ZMn3M6bs4nWyZRffVhKllMcqJRgvrlbZFXkQWUk1d3Yu5bSMnQWPVwn/1YKNqIRzu8RDrzcT/dlhS5VofHtIA==",
       "requires": {
-        "ssb-conn-db": "~0.2.1",
+        "ssb-conn-db": "~0.3.0",
         "ssb-conn-hub": "~0.2.7",
         "ssb-conn-staging": "~0.1.0"
       }
@@ -8015,9 +8015,9 @@
       }
     },
     "ssb-typescript": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-1.4.0.tgz",
-      "integrity": "sha512-+qFUlFGTIR9f4ab45UfszGCBiClSPH1llM072zWiwlxMyKu70CQ4IUgsWGWyge2mN8z9CiNkPm+ElZ5Ok0Mxcg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ssb-typescript/-/ssb-typescript-1.5.0.tgz",
+      "integrity": "sha512-I4oe7BDYmk3kopVZC4BrXuKfugpJphLcZTmheofW2Dwanm6VutLfzLgz6juqt7aYKeIH5Ps3sJvZWQLw3MvUMQ=="
     },
     "ssb-unix-socket": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ssb-blobs": "^1.2.2",
     "ssb-client": "^4.7.9",
     "ssb-config": "^3.4.3",
-    "ssb-conn": "~0.12.0",
+    "ssb-conn": "~0.15.1",
     "ssb-db": "^19.3.0",
     "ssb-ebt": "^5.6.7",
     "ssb-friends": "^4.1.4",


### PR DESCRIPTION
This is mostly a small update to ssb-conn, here are some highlights (from most relevant to least):

- **mark old and failing peers as defunct in the DB**
  - there are lots of dead pubs in your typical conn.json, and those are all going to be (at some point) attempted for a connection
  - I went through most of these and realized that those with hundreds of failures were very likely to be dead pubs
  - this update will detect pubs with 200+ failures, and mark them as defunct in the conn.json
  - defunct means this peer will never be attempted for a connection again by this scheduler (maybe other schedulers that people implement could ignore this)
  - we can't just delete these peers from the conn.json, because they would be re-added to conn.json when your SSB app queries the flumelog for messages of type "pub"
  - but peers marked "defunct" have a bunch of fields deleted, this means that the size of conn.json gets compressed
  - for instance mine went **from 534 KB to 189 KB**
- **update scheduler: remove neverJustOne, it was hard to justify it**
  - tiny update to the scheduler's behavior
  - before, when it picked a pub to connect with, it always picked *two* of them to maximize chances of connecting
  - that was quite an arbitrary decision, and didn't always make sense, so I removed it
- **update ssb-conn-db with self-healing conn.json**
  - conn.json files can get corrupted (see https://github.com/flumedb/atomic-file/issues/4), so this update will check if it's corrupted and try to do its best to recover the contents 
  - but this is mostly on mobile, I haven't seen this happening on desktop