### PR TITLE
Make the settings keyboard shortcut local instead of global

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,6 +94,16 @@ electron.app.on('ready', () => {
           click: () => {
             browserWindow.webContents.send('goForward')
           }
+        },
+        {
+          type: 'separator'
+        },
+        {
+          label: 'Settings',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => {
+            browserWindow.webContents.send('goToSettings')
+          }
         }
       ]
     })

--- a/lib/main-window.js
+++ b/lib/main-window.js
@@ -63,10 +63,6 @@ module.exports = function (config) {
   const includeParticipating = api.settings.obs.get('patchwork.includeParticipating', false)
   const autoDeleteBlocked = api.settings.obs.get('patchwork.autoDeleteBlocked', false)
 
-  electron.remote.globalShortcut.register('CmdOrCtrl+,', () => {
-    toggleView('/settings')
-  })
-
   // prompt to setup profile on first use
   onceTrue(api.sbot.obs.connection, (ssb) => {
     ssb.latestSequence(api.keys.sync.id(), (err, key) => {
@@ -145,6 +141,8 @@ module.exports = function (config) {
 
   electron.ipcRenderer.on('goForward', views.goForward)
   electron.ipcRenderer.on('goBack', views.goBack)
+
+  electron.ipcRenderer.on('goToSettings', () => api.app.navigate('/settings'))
 
   document.head.appendChild(
     h('style', {
@@ -253,8 +251,6 @@ module.exports = function (config) {
     ),
     views.html
   ])
-
-  const toggleView = view => { if (views.currentView() === view) { views.goBack() } else { navigate(view) } }
 
   const previewElement = api.app.linkPreview(container, 500)
 


### PR DESCRIPTION
See https://github.com/ssbc/patchwork/issues/1240 for background.

To make a keyboard shortcut local in Electron, it has to be put in some menu. I put it under _Navigation_ below a separator, with the idea that maybe some other views could be added there as well.

<img width="225" alt="Näyttökuva 2020-1-27 kello 17 47 04" src="https://user-images.githubusercontent.com/34607/73189423-09aeb600-412d-11ea-9413-6b0306e28f36.png">
