### PR TITLE
Fixes issue #1256

### DIFF
--- a/styles/base/feed-meta-summary.mcss
+++ b/styles/base/feed-meta-summary.mcss
@@ -34,8 +34,9 @@ FeedMetaSummary {
         img {
           display: block
           width: 45px
-          min-height: 30px
+          height: 45px
           border-radius: 3px
+          object-fit: cover
         }
         -channel {
           font-size: 20px

--- a/styles/base/message.mcss
+++ b/styles/base/message.mcss
@@ -23,6 +23,7 @@ Message {
         img {
           width: 50px
           height: 50px
+          object-fit: cover
         }
       }
       div.main {
@@ -247,6 +248,7 @@ Message {
           img {
             width: 40px
             height: 40px
+            object-fit: cover
           }
         }
       }
@@ -291,6 +293,7 @@ Message {
           img {
             width: 40px
             height: 40px
+            object-fit: cover
           }
         }
       }

--- a/styles/base/profile-list.mcss
+++ b/styles/base/profile-list.mcss
@@ -41,6 +41,7 @@ ProfileList {
         height: 40px
         display: block
         border-radius: 5px
+        object-fit: cover
       }
     }
     div.main {

--- a/styles/base/taggers-list.mcss
+++ b/styles/base/taggers-list.mcss
@@ -39,6 +39,7 @@ TaggersList {
         width: 40px
         height: 40px
         display: block
+        object-fit: cover
       }
     }
     div.main {


### PR DESCRIPTION
Setting the object-fit to `cover` for square images avoids stretched images.