### PR TITLE
Add super-short bio summary to mouseover popup.

### DIFF
--- a/lib/depject/message/async/name.js
+++ b/lib/depject/message/async/name.js
@@ -1,5 +1,6 @@
 const nest = require('depnest')
 const ref = require('ssb-ref')
+const { titleFromMarkdown, truncate } = require('../../../markdownSummary')
 const { resolve, onceTrue } = require('mutant')
 
 exports.needs = nest({
@@ -28,10 +29,10 @@ exports.create = function (api) {
         return cb(null, truncate(value.content.title, 40))
       } else if (value && value.content.type === 'post' && typeof value.content.text === 'string') {
         if (value.content.text.trim()) {
-          return cb(null, titleFromMarkdown(value.content.text, 40) || fallbackName)
+          return cb(null, titleFromMarkdown(value.content.text, 40, 3) || fallbackName)
         }
       } else if (value && typeof value.content.text === 'string') {
-        return cb(null, value.content.type + ': ' + titleFromMarkdown(value.content.text, 30))
+        return cb(null, value.content.type + ': ' + titleFromMarkdown(value.content.text, 30, 3))
       } else {
         return getAboutName(id, cb)
       }
@@ -48,20 +49,4 @@ exports.create = function (api) {
       cb(null, resolve(name) || resolve(title) || id.substring(0, 10) + '...')
     })
   }
-}
-
-function titleFromMarkdown (text, max) {
-  text = text.trim().split('\n', 3).join('\n')
-  text = text.replace(/_|`|\*|#|^\[@.*?]|\[|]|\(\S*?\)/g, '').trim()
-  text = text.replace(/:$/, '')
-  text = text.trim().split('\n', 1)[0].trim()
-  text = truncate(text, max)
-  return text
-}
-
-function truncate (text, maxLength) {
-  if (text.length > maxLength) {
-    text = text.substring(0, maxLength - 2) + '...'
-  }
-  return text
 }

--- a/lib/depject/profile/html/preview.js
+++ b/lib/depject/profile/html/preview.js
@@ -4,9 +4,11 @@ const map = require('mutant/map')
 const when = require('mutant/when')
 const computed = require('mutant/computed')
 const send = require('mutant/send')
+const removeMd = require('remove-markdown')
 
 exports.needs = nest({
   'about.obs.name': 'first',
+  'about.obs.description': 'first',
   'about.html.image': 'first',
   'keys.sync.id': 'first',
   'sheet.display': 'first',
@@ -25,8 +27,10 @@ exports.create = function (api) {
   const plural = api.intl.sync.i18n_n
 
   return nest('profile.html.preview', function (id) {
+    const idLen = id.length
     const name = api.about.obs.name(id)
     const contact = api.profile.obs.contact(id)
+    const description = api.about.obs.description(id)
 
     return h('ProfilePreview', [
       h('header', [
@@ -42,7 +46,15 @@ exports.create = function (api) {
           ]),
           h('section -publicKey', [
             h('pre', { title: i18n('Public key for this profile') }, id)
-          ])
+          ]),
+          h(
+            'section -profile', [
+              computed(description, (description) => {
+                const txt = removeMd(description)
+                const summary = shortenDescription(txt, idLen)
+                return summary
+              })]
+          )
         ])
       ]),
 
@@ -94,6 +106,31 @@ exports.create = function (api) {
       ])
     ])
   })
+
+  function shortenDescription (txt, len) {
+    if (txt == null) {
+      return ''
+    }
+    const line1 = txt.trim().split('\n', 1)[0]
+    if (line1.length <= len) {
+      return line1
+    }
+    const words = line1.split(' ')
+    let result = words.shift()
+    if (result.length > len) {
+      return result.splice(0, len - 1) + ' …'
+    }
+    for (let i = 0; i < len; i++) {
+      const currentWord = words.shift()
+      // + 1 for the joining space, and +2 for the final ellipsis
+      if (result.length + 1 + currentWord.length + 2 <= len) {
+        result += ` ${currentWord}`
+      } else {
+        break
+      }
+    }
+    return result + ' …'
+  }
 
   function displayMutualFriends (profiles) {
     api.sheet.profiles(profiles, i18n('Mutual Friends'))

--- a/lib/depject/profile/html/preview.js
+++ b/lib/depject/profile/html/preview.js
@@ -4,7 +4,7 @@ const map = require('mutant/map')
 const when = require('mutant/when')
 const computed = require('mutant/computed')
 const send = require('mutant/send')
-const removeMd = require('remove-markdown')
+const { titleFromMarkdown } = require('../../../markdownSummary')
 
 exports.needs = nest({
   'about.obs.name': 'first',
@@ -50,8 +50,9 @@ exports.create = function (api) {
           h(
             'section -profile', [
               computed(description, (description) => {
-                const txt = removeMd(description)
-                const summary = shortenDescription(txt, idLen)
+                // const txt = removeMd(description)
+                // const summary = shortenDescription(txt, idLen)
+                const summary = titleFromMarkdown(description, idLen, 1)
                 return summary
               })]
           )

--- a/lib/depject/profile/html/preview.js
+++ b/lib/depject/profile/html/preview.js
@@ -50,8 +50,6 @@ exports.create = function (api) {
           h(
             'section -profile', [
               computed(description, (description) => {
-                // const txt = removeMd(description)
-                // const summary = shortenDescription(txt, idLen)
                 const summary = titleFromMarkdown(description, idLen, 1)
                 return summary
               })]
@@ -107,31 +105,6 @@ exports.create = function (api) {
       ])
     ])
   })
-
-  function shortenDescription (txt, len) {
-    if (txt == null) {
-      return ''
-    }
-    const line1 = txt.trim().split('\n', 1)[0]
-    if (line1.length <= len) {
-      return line1
-    }
-    const words = line1.split(' ')
-    let result = words.shift()
-    if (result.length > len) {
-      return result.splice(0, len - 1) + ' …'
-    }
-    for (let i = 0; i < len; i++) {
-      const currentWord = words.shift()
-      // + 1 for the joining space, and +2 for the final ellipsis
-      if (result.length + 1 + currentWord.length + 2 <= len) {
-        result += ` ${currentWord}`
-      } else {
-        break
-      }
-    }
-    return result + ' …'
-  }
 
   function displayMutualFriends (profiles) {
     api.sheet.profiles(profiles, i18n('Mutual Friends'))

--- a/lib/markdownSummary.js
+++ b/lib/markdownSummary.js
@@ -11,7 +11,7 @@ exports.titleFromMarkdown = (text, max, maxLines) => {
   return text
 }
 
-exports.truncate  = (text, maxLength) => {
+exports.truncate = (text, maxLength) => {
   if (text.length > maxLength) {
     text = text.substring(0, maxLength - 2) + '...'
   }

--- a/lib/markdownSummary.js
+++ b/lib/markdownSummary.js
@@ -1,0 +1,19 @@
+
+exports.titleFromMarkdown = (text, max, maxLines) => {
+  if (text === null) {
+    return ''
+  }
+  text = text.trim().split('\n', maxLines + 1).join('\n')
+  text = text.replace(/_|`|\*|#|^\[@.*?]|\[|]|\(\S*?\)/g, '').trim()
+  text = text.replace(/:$/, '')
+  text = text.trim().split('\n', 1)[0].trim()
+  text = module.exports.truncate(text, max)
+  return text
+}
+
+exports.truncate  = (text, maxLength) => {
+  if (text.length > maxLength) {
+    text = text.substring(0, maxLength - 2) + '...'
+  }
+  return text
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5327,8 +5327,8 @@
       "integrity": "sha512-FJgjyX/IVkbXBXYUwH+OYwQKqWpFPLaLVESd70yHjSDunwzV2hZOoTBvPf4KLoxesUzzyfTH6F784Uqd7Wm5yA=="
     },
     "mutant": {
-      "version": "3.22.1",
-      "resolved": "github:mmckegg/mutant#e880acd7df1e14b67026d826902543ceb3556566",
+      "version": "github:mmckegg/mutant#e880acd7df1e14b67026d826902543ceb3556566",
+      "from": "github:mmckegg/mutant#intersection-binding-viewport",
       "requires": {
         "browser-split": "0.0.1",
         "source-map-support": "^0.5.9",
@@ -6899,6 +6899,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/relative-url/-/relative-url-1.0.2.tgz",
       "integrity": "sha1-0hxSpy1gYQGLzun5yfwQa/fWUoc="
+    },
+    "remove-markdown": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.3.0.tgz",
+      "integrity": "sha1-XktmdJOpNXlyjz1S7MHbnKUF3Jg="
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "pull-pushable": "^2.2.0",
     "pull-reconnect": "0.0.3",
     "pull-stream": "^3.6.14",
+    "remove-markdown": "^0.3.0",
     "require-style": "^1.1.0",
     "run-parallel": "^1.1.9",
     "scuttle-blog": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "pull-pushable": "^2.2.0",
     "pull-reconnect": "0.0.3",
     "pull-stream": "^3.6.14",
-    "remove-markdown": "^0.3.0",
     "require-style": "^1.1.0",
     "run-parallel": "^1.1.9",
     "scuttle-blog": "^1.0.1",


### PR DESCRIPTION
This addresses #780 in a relatively hap-hazard way.
I basically just tried to copy what the code around this feature was doing. 
Also I didn't know any other way to ditch markdown syntax than to include a new dependency.

Alternatively we could just pass the raw markdown, and hope that users will notice that it doesn't look so great, and just have super-short bios in their profiles' first lines. :stuck_out_tongue: 