### PR TITLE
Handle travis cache more delicately.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
 
 cache:
   directories:
-    - $HOME/.npm
     - $HOME/.cache/electron
     - $HOME/.cache/electron-builder
 
@@ -34,6 +33,7 @@ before_install:
         libxkbfile-dev \
         libxtst-dev
     fi
+  - npm cache verify
 
 script: npm test && npm run dist
 


### PR DESCRIPTION
After debugging in #1277, it seems that our travis cache got corrupted.
This simply puts a cache verification step in front of the build process.
If the caching becomes a problem now, we shoul at least get some clear
info on what's happening.

Also, this disables explicit caching of ~/.npm, because that is handled
implicitly by travis these days.