### PR TITLE
Allow navigation to my own profile via search bar.

### DIFF
--- a/lib/depject/app/html/search.js
+++ b/lib/depject/app/html/search.js
@@ -7,12 +7,13 @@ const electron = require('electron')
 exports.needs = nest({
   'profile.async.suggest': 'first',
   'channel.async.suggest': 'first',
-  'intl.sync.i18n': 'first'
+  'intl.sync.i18n': 'first',
+  'keys.sync.id': 'first'
 })
 
 exports.gives = nest('app.html.search')
 
-const pages = ['/public', '/private', '/mentions', '/all', '/gatherings', '/participating', '/attending-gatherings']
+const pages = ['/public', '/private', '/mentions', '/all', '/gatherings', '/participating', '/attending-gatherings', '/profile']
 
 exports.create = function (api) {
   const i18n = api.intl.sync.i18n
@@ -78,10 +79,18 @@ exports.create = function (api) {
 
     function getPageSuggestions (input) {
       return pages.sort().filter(p => p.startsWith(input.toLowerCase())).map(p => {
+        if (p !== '/profile') {
+          return {
+            id: p,
+            value: p,
+            title: p
+          }
+        }
+        const id = api.keys.sync.id()
         return {
-          id: p,
-          value: p,
-          title: p
+          id: id,
+          value: '/profile',
+          title: '/profile'
         }
       })
     }


### PR DESCRIPTION
So far, the search bar included all the main views *except* the Profile.
This was supposedly because for the other views the navigation is trivially
done by a string constant, while navigating to the user's profile requires
navigating to their feed ID.
So this introduces the navigation to /profile as an alias to navigating to
the user's own feed ID.