### PR TITLE
Show last feed activity in profile

### DIFF
--- a/lib/depject/message/html/timestamp.js
+++ b/lib/depject/message/html/timestamp.js
@@ -11,11 +11,15 @@ exports.needs = nest({
 exports.create = function (api) {
   return nest('message.html.timestamp', timestamp)
 
-  function timestamp (msg) {
-    return h('a.Timestamp', {
-      href: api.message.sync.root(msg) || msg.key,
-      anchor: msg.key,
-      title: moment(api.message.sync.timestamp(msg)).format('LLLL zz')
-    }, moment(api.message.sync.timestamp(msg)).fromNow())
+  function timestamp (msg, link = true) {
+    if (link) {
+      return h('a.Timestamp', {
+        href: api.message.sync.root(msg) || msg.key,
+        anchor: msg.key,
+        title: moment(api.message.sync.timestamp(msg)).format('LLLL zz')
+      }, moment(api.message.sync.timestamp(msg)).fromNow())
+    } else {
+      return moment(api.message.sync.timestamp(msg)).fromNow()
+    }
   }
 }

--- a/lib/depject/page/html/render/profile.js
+++ b/lib/depject/page/html/render/profile.js
@@ -156,8 +156,9 @@ exports.create = function (api) {
     const prepend = h('header', { className: 'ProfileHeader' }, [
       h('div.image', [
         api.about.html.image(id),
-        h('div.lastActivity', computed(lastActivity, msg => `Last activity: ${api.message.html.timestamp(msg, false)}`))
-      ]),
+        h('div.lastActivity',
+          computed(lastActivity,
+            msg => `${i18n('Last activity')}: ${api.message.html.timestamp(msg, false)}`))]),
       h('div.main', [
         h('div.title', [
           h('h1', [name]),

--- a/lib/depject/page/html/render/profile.js
+++ b/lib/depject/page/html/render/profile.js
@@ -1,6 +1,6 @@
 const nest = require('depnest')
 const ref = require('ssb-ref')
-const { h, when, computed, map, send, dictToCollection, resolve, onceTrue } = require('mutant')
+const { h, when, computed, map, send, dictToCollection, resolve, onceTrue, Value } = require('mutant')
 
 exports.needs = nest({
   'about.obs': {
@@ -14,12 +14,14 @@ exports.needs = nest({
   'blob.html.input': 'first',
   'message.async.publish': 'first',
   'message.html.markdown': 'first',
+  'message.html.timestamp': 'first',
   'message.sync.root': 'first',
   'about.html.image': 'first',
   'feed.html.rollup': 'first',
   'sbot.pull.resumeStream': 'first',
   'sbot.pull.stream': 'first',
   'sbot.async.publish': 'first',
+  'sbot.async.getLatest': 'first',
   'sbot.obs.connection': 'first',
   'keys.sync.id': 'first',
   'sheet.display': 'first',
@@ -45,6 +47,16 @@ exports.create = function (api) {
     const contact = api.profile.obs.contact(id)
     const recent = api.profile.obs.recentlyUpdated()
     const isYou = id === yourId
+    const lastActivity = Value()
+    api.sbot.async.getLatest(id, (err, val) => {
+      if (err) {
+        console.dir(err)
+      } else {
+        if (val) {
+          lastActivity.set(val)
+        }
+      }
+    })
 
     onceTrue(api.sbot.obs.connection, sbot => {
       // request a once off replicate of this feed
@@ -142,7 +154,10 @@ exports.create = function (api) {
     ])
 
     const prepend = h('header', { className: 'ProfileHeader' }, [
-      h('div.image', api.about.html.image(id)),
+      h('div.image', [
+        api.about.html.image(id),
+        h('div.lastActivity', computed(lastActivity, msg => `Last activity: ${api.message.html.timestamp(msg, false)}`))
+      ]),
       h('div.main', [
         h('div.title', [
           h('h1', [name]),

--- a/lib/depject/sbot.js
+++ b/lib/depject/sbot.js
@@ -25,6 +25,7 @@ exports.gives = {
     },
     async: {
       get: true,
+      getLatest: true,
       publish: true,
       addBlob: true,
       connConnect: true,
@@ -141,6 +142,15 @@ exports.create = function (api) {
               cb(null, value)
             })
           }
+        }),
+        getLatest: rec.async(function (id, cb) {
+          if (typeof cb !== 'function') {
+            throw new Error('cb must be function')
+          }
+          sbot.getLatest(id, function (err, value) {
+            if (err) return cb(err)
+            cb(null, value)
+          })
         }),
         publish: rec.async((content, cb) => {
           const indexes = api.progress.obs.indexes()


### PR DESCRIPTION
Brought up by [@kas](@RuNxm8SRujPcJx6GjtTQHp6hprAFv5voEkcvoAkB8Pk=.ed25519) in [`%j0/mywlnDar3HJ6ED34ICxzyep3QhM0hvi1ov12A04s=.sha256`](https://ssb.muchmuch.coffee/%25j0%2FmywlnDar3HJ6ED34ICxzyep3QhM0hvi1ov12A04s%3D.sha256). This shows the timestamp of the last message received from a feed.

Not sure thought if I did this the right way, depject is still quite the mystery to me...
I *think* I got the data out of sbot the right way, but not about whether I hooked it up to mutant correctly.

Also not sure about the positioning in the profile view. I put it below the avatar. Always felt like that space was very empty, and this seems to fit in the quite nicely.
Anyhow, another learning experience :P