### PR TITLE
Reduce timestamp specificity on profile

### DIFF
--- a/lib/depject/message/html/timestamp.js
+++ b/lib/depject/message/html/timestamp.js
@@ -19,7 +19,11 @@ exports.create = function (api) {
         title: moment(api.message.sync.timestamp(msg)).format('LLLL zz')
       }, moment(api.message.sync.timestamp(msg)).fromNow())
     } else {
-      return moment(api.message.sync.timestamp(msg)).fromNow()
+      return moment(api.message.sync.timestamp(msg)).calendar(null, {
+        sameDay: '[Today]',
+        lastDay: '[Yesterday]',
+        lastWeek: '[Last] dddd'
+      })
     }
   }
 }


### PR DESCRIPTION
Problem: Concern has been expressed about being able to see granular
timestamps on the profile page, which would let you see "active 3
seconds ago" or similar. This is public metadata that anyone can access,
and we **can not** provide privacy with UI decisions, but the idea that
high specificity in the UI is creepy seems fair to me.

Solution: Change the display format so that the options are "Today",
"Yesterday", "Last $weekday", or the default date formate for the locale
in question. Since we aren't hardcoding strings, this should continue to
be localized.

---

https://momentjs.com/docs/#/displaying/calendar-time/