### PR TITLE
Ignore whitespace-only ContentWarnings.

### DIFF
--- a/lib/depject/message/html/compose.js
+++ b/lib/depject/message/html/compose.js
@@ -278,8 +278,9 @@ exports.create = function (api) {
         })
       })
 
-      if (contentWarningInput.value) {
-        content.contentWarning = contentWarningInput.value
+      const cw = contentWarningInput.value.trim()
+      if (cw.length > 0) {
+        content.contentWarning = cw
       }
 
       try {


### PR DESCRIPTION
This will break the workflow of people that use `"    "` or such as a CW
that means "beware, but I won't tell you why". :)

closes #1303 

I also thought to treat whitespace-only message body (in the compose input) as empty, and disable the publish button in that case. But that felt like a different issue.