### PR TITLE
update ssb-conn to 0.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7873,9 +7873,9 @@
       }
     },
     "ssb-conn": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.16.2.tgz",
-      "integrity": "sha512-KinjdF3tOMmlcjKK4bnTso0x6GYfL+9tE2gSacRDldaLui73nDLxSwjnSoE188wDXUEumJU0LvOff4AHm2XyLQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/ssb-conn/-/ssb-conn-0.18.1.tgz",
+      "integrity": "sha512-hwcJGLnCWT5YN7T6JyaW42/dybcWwmO5Lc2bEv1BsPcoamdcNU/sHpT1v5bRY65GD0pPSap5YwTwYiHFl+cdbg==",
       "requires": {
         "debug": "~4.1.1",
         "has-network2": "0.0.1",
@@ -7913,9 +7913,9 @@
       }
     },
     "ssb-conn-db": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.1.tgz",
-      "integrity": "sha512-1cCbfaVDow50FNx+0V1hGIJsSy1RIn10J16D/gBlWRxB1ddGr5v6TCtFyc6Y+J/6Gnx+BPTKwqd9vTJ1ow6RCA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ssb-conn-db/-/ssb-conn-db-0.3.2.tgz",
+      "integrity": "sha512-3dgUU1sfM9cwPRYh2m4A08ebDr/kOKBQ7NMRLz/K0aK12wAjDEGSNCownzIqK/dLLdPXEJHU41kMLquR8Vdn8A==",
       "requires": {
         "atomic-file": "^1.1.5",
         "debug": "~4.1.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ssb-blobs": "^1.2.2",
     "ssb-client": "^4.9.0",
     "ssb-config": "^3.4.4",
-    "ssb-conn": "~0.16.2",
+    "ssb-conn": "~0.18.1",
     "ssb-db": "^19.4.0",
     "ssb-dht-invite": "~1.11.0",
     "ssb-ebt": "^5.6.7",


### PR DESCRIPTION
Biggest changes are:

- support `config.conn.hops` to determine automatic connections https://github.com/staltz/ssb-conn/commit/12a17f22eefb5c5c7bd0e462352b314f0c008fcd
- less deprecation warnings in the console https://github.com/staltz/ssb-conn/commit/b8cd3bcfaf4898ba09ea7ff6a983abb9ed15a981
- prioritize connecting to friends if they are staged https://github.com/staltz/ssb-conn/commit/433c19b822a83c63f42a7184e628a1257cc484ef
- fix exception after closing https://github.com/staltz/ssb-conn/commit/e3c47f07aa4b3b69d5422a6a1e34b5d1764663ef