### PR TITLE
ssb dependency version bumps: the easy parts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4116,6 +4116,113 @@
         "pull-write": "^1.1.1"
       }
     },
+    "flumeview-links": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/flumeview-links/-/flumeview-links-2.1.0.tgz",
+      "integrity": "sha512-VzqbNJ9qYE9eopCrhWXlPSoIoW4xanMy6YFyVSaYAwQIPoIZ+F1s1D3vmzOLXGhPesgHiXAlxmFSzXM5C9DKbQ==",
+      "requires": {
+        "deep-equal": "^2.0.3",
+        "flumeview-level": "^4.0.3",
+        "map-filter-reduce": "^3.2.2",
+        "pull-flatmap": "0.0.1",
+        "pull-stream": "^3.6.14"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "encoding-down": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+          "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+          "requires": {
+            "abstract-leveldown": "^6.2.1",
+            "inherits": "^2.0.3",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0"
+          }
+        },
+        "flumeview-level": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-4.0.4.tgz",
+          "integrity": "sha512-8C/o/oZU73ot1LMbxCyKeZJ0D3L5AGdxzIF5H2QtmznMSoZHVG1gT2IDjkOtesenVPlLQKnL95ewMKbE7cXWEw==",
+          "requires": {
+            "charwise": "^3.0.1",
+            "explain-error": "^1.0.4",
+            "level": "^6.0.1",
+            "ltgt": "^2.1.3",
+            "mkdirp": "^1.0.4",
+            "obz": "^1.0.2",
+            "pull-level": "^2.0.3",
+            "pull-paramap": "^1.2.1",
+            "pull-stream": "^3.6.14",
+            "pull-write": "^1.1.1"
+          }
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          }
+        },
+        "level-packager": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+          "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+          "requires": {
+            "encoding-down": "^6.3.0",
+            "levelup": "^4.3.2"
+          }
+        },
+        "leveldown": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+          "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+          "requires": {
+            "abstract-leveldown": "~6.2.1",
+            "napi-macros": "~2.0.0",
+            "node-gyp-build": "~4.1.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        }
+      }
+    },
     "flumeview-query": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-6.3.0.tgz",
@@ -8754,26 +8861,20 @@
       }
     },
     "ssb-backlinks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-1.0.0.tgz",
-      "integrity": "sha512-cgBfw+5oQMmFWX5czTHonZboZC9rRgZZlC2TwkSZvOZMWNxZKr98zvb56lRFiO4Et6DcEh3hXsyZyMyo6jN0WA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ssb-backlinks/-/ssb-backlinks-2.1.1.tgz",
+      "integrity": "sha512-iv/B5EyjvNiKOeT3RkTuBRyU14GJ1sf5wnr07JOWeVI3OyNzedZ8z229yzZSaGHTYpbiSOcs9Z2CR8CkLQupQQ==",
       "requires": {
-        "base64-url": "^2.2.0",
-        "flumeview-query": "^6.2.0",
-        "pull-stream": "^3.6.7",
-        "ssb-keys": "^7.0.14",
-        "ssb-ref": "^2.9.0"
+        "base64-url": "^2.3.3",
+        "flumeview-links": "^2.1.0",
+        "pull-stream": "^3.6.14",
+        "ssb-ref": "^2.14.0"
       },
       "dependencies": {
-        "ssb-keys": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
-          "integrity": "sha512-FPeyYU/3LpxcagnbmVWE+Q/qzg6keqeOBPbD7sEH9UKixUASeufPKiORDgh8nVX7J9Z+0vUaHt/WG999kGjvVQ==",
-          "requires": {
-            "chloride": "^2.2.8",
-            "mkdirp": "~0.5.0",
-            "private-box": "^0.3.0"
-          }
+        "base64-url": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-2.3.3.tgz",
+          "integrity": "sha512-dLMhIsK7OplcDauDH/tZLvK7JmUZK3A7KiQpjNzsBrM6Etw7hzNI1tLEywqJk9NnwkgWuFKSlx/IUO7vF6Mo8Q=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7719,9 +7719,9 @@
       "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
     },
     "pull-reconnect": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/pull-reconnect/-/pull-reconnect-0.0.3.tgz",
-      "integrity": "sha1-U9zpzS8rmyEOiIleGfL/xnYh3J4=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pull-reconnect/-/pull-reconnect-0.1.1.tgz",
+      "integrity": "sha512-401QYdRYKqe2vlDXbKmEUGALJvBlRYYWuK6EDHcMb36KFTm5+pdEG+vqNuZ6S+C1U8qDB37KJ2JI8ZqS6sYG3A==",
       "requires": {
         "pull-defer": "^0.2.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3041,9 +3041,9 @@
       }
     },
     "entities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "env-paths": {
       "version": "2.2.0",
@@ -5871,12 +5871,12 @@
       "integrity": "sha1-am/FjJXYqrRsK93kTVFbbuBvzjQ="
     },
     "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
@@ -9415,17 +9415,18 @@
       }
     },
     "ssb-markdown": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-6.0.4.tgz",
-      "integrity": "sha512-MdmHnev7259wzGcCSBo6A93kR/3iIx5sWrrzFTuyDmAAgHLycvotS6tbcge15AlPZDNRmo2N3MyHKTYb+SYbUA==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ssb-markdown/-/ssb-markdown-6.0.7.tgz",
+      "integrity": "sha512-uM+wfgh+piiFtTGhLJvdduhPdaH2E15Da0dOlg8C+9hPHb3ePz5nqfdioHah2CkIMRvjhVWHmUMbGQks/RxtIg==",
       "requires": {
         "emoji-regex": "^8.0.0",
         "hashtag-regex": "^2.1.0",
-        "highlight.js": "^9.15.8",
-        "markdown-it": "^8.4.2",
+        "highlight.js": "^9.18.1",
+        "markdown-it": "^10.0.0",
         "markdown-it-emoji": "^1.4.0",
         "markdown-it-hashtag": "^0.4.0",
-        "node-emoji": "^1.10.0"
+        "node-emoji": "^1.10.0",
+        "ssb-ref": "^2.13.9"
       },
       "dependencies": {
         "highlight.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8923,15 +8923,15 @@
       }
     },
     "ssb-blob-files": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ssb-blob-files/-/ssb-blob-files-1.2.0.tgz",
-      "integrity": "sha512-5j7D2El/4kIKqoWLx/bb4XQwDbOhBEm+ccNF84wlPSl5z/lPoMHlK8BTYQ6NT+wZKTw2E8o4G3IqTqAiwpYweA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ssb-blob-files/-/ssb-blob-files-1.2.1.tgz",
+      "integrity": "sha512-O4uqyjpGOxfsGP2APlX9kMvz95stbBVrtnIGXO2vxVtjTtVhoOVXwW7zGdLsiyVo8tDx2YJibZ23Mv2nsdA5lg==",
       "requires": {
-        "piexifjs": "^1.0.4",
+        "piexifjs": "^1.0.6",
         "pull-box-stream": "^1.0.13",
         "pull-defer": "^0.2.3",
-        "pull-stream": "^3.6.9",
-        "read-directory": "^3.0.0",
+        "pull-stream": "^3.6.14",
+        "read-directory": "^3.0.2",
         "simple-mime": "^0.1.0",
         "split-buffer": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9395,45 +9395,16 @@
       }
     },
     "ssb-friends": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.1.4.tgz",
-      "integrity": "sha512-rjQP2rLocqnUoiI+SSUehLQwMB4H5TKD13hfnweGVIgAWw4mylbl9bPOuXtTU23ubPkdbSNadlp3uivsCkWLxw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ssb-friends/-/ssb-friends-4.3.0.tgz",
+      "integrity": "sha512-5NgtiuYM8M2g8crzQF2nCpenM70zhsb6PNeL6B0iXalAl/IN2wwEWSUhU8++2gTh9dZ7icZJ8nC/kCzIoUdmgA==",
       "requires": {
-        "flumeview-reduce": "^1.3.0",
+        "flumeview-reduce": "^1.3.17",
         "layered-graph": "^1.1.1",
         "pull-flatmap": "0.0.1",
         "pull-notify": "^0.1.1",
         "pull-stream": "^3.6.0",
         "ssb-ref": "^2.7.1"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-          "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
-          }
-        },
-        "flumeview-reduce": {
-          "version": "1.3.17",
-          "resolved": "https://registry.npmjs.org/flumeview-reduce/-/flumeview-reduce-1.3.17.tgz",
-          "integrity": "sha512-Li09TntlRpN51GtFKllIh5nDdBcyDazvi5a/yvbdUCS9xAFb8OA6H6uu32W9gG+4GyvfUi9AsOyN8RQ8OcREQA==",
-          "requires": {
-            "async-single": "^1.0.5",
-            "atomic-file": "^2.0.0",
-            "deep-equal": "^1.0.1",
-            "flumecodec": "0.0.0",
-            "obv": "0.0.1",
-            "pull-notify": "^0.1.1",
-            "pull-stream": "^3.5.0"
-          }
-        }
       }
     },
     "ssb-invite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9069,9 +9069,9 @@
       }
     },
     "ssb-config": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.4.tgz",
-      "integrity": "sha512-J3fsWb5nS6PqObZLW2tclEz/bkRQ5pcF9goXanYGVsoH71F6W4f5sOnck9szeubI8srNaiL9pa0kPRv/lojHiw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-config/-/ssb-config-3.4.5.tgz",
+      "integrity": "sha512-DyCrGIsl01GkdHreAkkaDUorV7SAgRSqKn/htg4ZwbvH6g0NAdOi84x/8ehzDuojPev78hbkWjZXgIqi+/Jo0g==",
       "requires": {
         "deep-extend": "^0.6.0",
         "ip": "^1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9603,43 +9603,134 @@
       }
     },
     "ssb-query": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.3.tgz",
-      "integrity": "sha512-Ktuk6Bl3s70gueDH7FBXzI8KHsf+h+n82J6Id33NTwP80u5iSDV5vXK2f7/He/cmP3uUVUI5ogJda7ShmrDIug==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/ssb-query/-/ssb-query-2.4.5.tgz",
+      "integrity": "sha512-/QX6+DJkghqq1ZTbgYpOvaI+gx2O7ee1TRUM9yiOlVjh1XAQBevcBj0zO+W3TsNllX86urqBrySd/AEfFfUpIw==",
       "requires": {
         "explain-error": "^1.0.1",
-        "flumeview-query": "^7.0.0",
+        "flumeview-query": "^8.0.0",
         "pull-stream": "^3.6.2"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "deep-equal": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+          "requires": {
+            "is-arguments": "^1.0.4",
+            "is-date-object": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "object-is": "^1.0.1",
+            "object-keys": "^1.1.1",
+            "regexp.prototype.flags": "^1.2.0"
+          }
+        },
+        "encoding-down": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+          "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+          "requires": {
+            "abstract-leveldown": "^6.2.1",
+            "inherits": "^2.0.3",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0"
+          }
+        },
+        "flumeview-level": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/flumeview-level/-/flumeview-level-4.0.4.tgz",
+          "integrity": "sha512-8C/o/oZU73ot1LMbxCyKeZJ0D3L5AGdxzIF5H2QtmznMSoZHVG1gT2IDjkOtesenVPlLQKnL95ewMKbE7cXWEw==",
+          "requires": {
+            "charwise": "^3.0.1",
+            "explain-error": "^1.0.4",
+            "level": "^6.0.1",
+            "ltgt": "^2.1.3",
+            "mkdirp": "^1.0.4",
+            "obz": "^1.0.2",
+            "pull-level": "^2.0.3",
+            "pull-paramap": "^1.2.1",
+            "pull-stream": "^3.6.14",
+            "pull-write": "^1.1.1"
+          }
+        },
         "flumeview-query": {
-          "version": "7.2.1",
-          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-7.2.1.tgz",
-          "integrity": "sha512-iLr5S+BrGJIls30jR42L0g/gehSrJmAlYIQhcu0fNpUW5dOq7sfa8rOmJo0lpC2Ns5EIgGogR6uO8ze7qWFvLQ==",
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/flumeview-query/-/flumeview-query-8.0.0.tgz",
+          "integrity": "sha512-uPTT5I26ePMc6Xhjebu1aiaHAd7P3EqyE9SZB6B9ZIvXtMXhFYNk7iO1yzh1ZXp3aYzdYmrI9k8mSz9urZ9gNQ==",
           "requires": {
             "deep-equal": "^1.0.1",
-            "flumeview-level": "^3.0.0",
+            "flumeview-level": "^4.0.3",
             "map-filter-reduce": "^3.2.0",
             "pull-flatmap": "0.0.1",
             "pull-paramap": "^1.1.3",
             "pull-sink-through": "0.0.0",
             "pull-stream": "^3.4.0"
-          },
-          "dependencies": {
-            "deep-equal": {
-              "version": "1.1.1",
-              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-              "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-              "requires": {
-                "is-arguments": "^1.0.4",
-                "is-date-object": "^1.0.1",
-                "is-regex": "^1.0.4",
-                "object-is": "^1.0.1",
-                "object-keys": "^1.1.1",
-                "regexp.prototype.flags": "^1.2.0"
-              }
-            }
           }
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          }
+        },
+        "level-packager": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+          "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+          "requires": {
+            "encoding-down": "^6.3.0",
+            "levelup": "^4.3.2"
+          }
+        },
+        "leveldown": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+          "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+          "requires": {
+            "abstract-leveldown": "~6.2.1",
+            "napi-macros": "~2.0.0",
+            "node-gyp-build": "~4.1.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,37 +1221,6 @@
         }
       }
     },
-    "bl": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
-      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
-      "requires": {
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "blake2s": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blake2s/-/blake2s-1.1.0.tgz",
@@ -1657,23 +1626,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
-    },
-    "bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
-      "requires": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
-      "requires": {
-        "typewise-core": "^1.2"
-      }
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -5663,103 +5615,6 @@
         "ltgt": "^2.1.2"
       }
     },
-    "level-sublevel": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
-      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
-      "requires": {
-        "bytewise": "~1.1.0",
-        "levelup": "~0.19.0",
-        "ltgt": "~2.1.1",
-        "pull-defer": "^0.2.2",
-        "pull-level": "^2.0.3",
-        "pull-stream": "^3.6.8",
-        "typewiselite": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
-          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
-          "requires": {
-            "xtend": "~3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "deferred-leveldown": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
-          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
-          "requires": {
-            "abstract-leveldown": "~0.12.1"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "levelup": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
-          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
-          "requires": {
-            "bl": "~0.8.1",
-            "deferred-leveldown": "~0.2.0",
-            "errno": "~0.1.1",
-            "prr": "~0.0.0",
-            "readable-stream": "~1.0.26",
-            "semver": "~5.1.0",
-            "xtend": "~3.0.0"
-          },
-          "dependencies": {
-            "xtend": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-            }
-          }
-        },
-        "ltgt": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
-          "integrity": "sha1-EIUaBtmWS5cReEQcI8nlJpjuzjQ="
-        },
-        "prr": {
-          "version": "0.0.0",
-          "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-          "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "semver": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
-          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-        }
-      }
-    },
     "level-supports": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.0.tgz",
@@ -9408,21 +9263,91 @@
       }
     },
     "ssb-invite": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.4.tgz",
-      "integrity": "sha512-bq4Iow4DOfsfWKE6otgD2+sWd59PcLW/WUbwZdJlukaT2m0nazPu2s8k9xX/95p+pJS7xkLyywHxMzytiKRqTg==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/ssb-invite/-/ssb-invite-2.1.6.tgz",
+      "integrity": "sha512-cR2sMFu27K7JNAiHCJ5qsp5kihlxi0/KftJ58gFzQbC8kLQ9iLLFUVDvQMi/Qxubf6Xs37Qh49FH3RzPLGt9ag==",
       "requires": {
         "cont": "^1.0.3",
         "explain-error": "^1.0.4",
         "ip": "^1.1.5",
-        "level": "^5.0.0",
-        "level-sublevel": "^6.6.5",
-        "muxrpc-validation": "^3.0.0",
-        "ssb-client": "^4.7.4",
-        "ssb-keys": "^7.1.3",
-        "ssb-ref": "^2.13.9"
+        "level": "^6.0.1",
+        "muxrpc-validation": "^3.0.2",
+        "ssb-client": "^4.9.0",
+        "ssb-keys": "^7.2.2",
+        "ssb-ref": "^2.14.0"
       },
       "dependencies": {
+        "abstract-leveldown": {
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
+          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "immediate": "^3.2.3",
+            "level-concat-iterator": "~2.0.0",
+            "level-supports": "~1.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "encoding-down": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+          "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+          "requires": {
+            "abstract-leveldown": "^6.2.1",
+            "inherits": "^2.0.3",
+            "level-codec": "^9.0.0",
+            "level-errors": "^2.0.0"
+          }
+        },
+        "level": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
+          "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
+          "requires": {
+            "level-js": "^5.0.0",
+            "level-packager": "^5.1.0",
+            "leveldown": "^5.4.0"
+          }
+        },
+        "level-codec": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+          "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+          "requires": {
+            "buffer": "^5.6.0"
+          }
+        },
+        "level-js": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.2.tgz",
+          "integrity": "sha512-SnBIDo2pdO5VXh02ZmtAyPP6/+6YTJg2ibLtl9C34pWvmtMEmRTWpra+qO/hifkUtBTOtfx6S9vLDjBsBK4gRg==",
+          "requires": {
+            "abstract-leveldown": "~6.2.3",
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.3",
+            "ltgt": "^2.1.2"
+          }
+        },
+        "level-packager": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
+          "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
+          "requires": {
+            "encoding-down": "^6.3.0",
+            "levelup": "^4.3.2"
+          }
+        },
+        "leveldown": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
+          "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
+          "requires": {
+            "abstract-leveldown": "~6.2.1",
+            "napi-macros": "~2.0.0",
+            "node-gyp-build": "~4.1.0"
+          }
+        },
         "ssb-keys": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/ssb-keys/-/ssb-keys-7.2.2.tgz",
@@ -10615,19 +10540,6 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
-    },
-    "typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
-      "requires": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha1-l+uRgFx/VdL5QXSPpQ0xXZke8ZU="
     },
     "typewiselite": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "pull-paramap": "^1.2.2",
     "pull-pause": "~0.0.2",
     "pull-pushable": "^2.2.0",
-    "pull-reconnect": "0.0.3",
+    "pull-reconnect": "0.1.1",
     "pull-stream": "^3.6.14",
     "require-style": "^1.1.0",
     "run-parallel": "^1.1.9",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sorted-array-functions": "^1.2.0",
     "spacetime": "^6.4.1",
     "ssb-about": "github:ssbc/ssb-about#use-await-ready",
-    "ssb-backlinks": "^1.0.0",
+    "ssb-backlinks": "^2.1.1",
     "ssb-blob-files": "^1.2.0",
     "ssb-blobs": "^2.0.1",
     "ssb-client": "^4.9.0",


### PR DESCRIPTION
These are the version bumps that are no-ops or trivial, or are themselves mostly docs, tests, and version bumps themselves.

This will recompute some indexes due to changes in their dependencies:

- `ssb-private`, `ssb-friends`, and `ssb-query` bump `flumeview-query`
- `ssb-backlinks` bumps `flumeview-links`

So a bit of reindexing time is expected, which means patchwork will start up but then look quite empty and use a bunch of CPU & I/O for a while.