### PR TITLE
[WIP] display blocking reasons

### DIFF
--- a/lib/depject/feed/html/meta-summary.js
+++ b/lib/depject/feed/html/meta-summary.js
@@ -121,7 +121,7 @@ function getActions (msgs) {
     if (content.type === 'contact') {
       if (ref.isFeed(content.contact)) {
         const to = content.contact
-        const key = `${from}:${to}`
+        const key = `subscribe:${from}:${to}`
         if (content.following === true) {
           if (actions[key] === 'unfollowed') {
             delete actions[key]
@@ -152,7 +152,7 @@ function getActions (msgs) {
       const channel = ref.normalizeChannel(content.channel)
       if (channel) {
         const to = '#' + channel
-        const key = `${from}:${to}`
+        const key = `subscribe:${from}:${to}`
         if (content.subscribed === true) {
           if (actions[key] === 'unsubscribed') {
             delete actions[key]
@@ -170,7 +170,7 @@ function getActions (msgs) {
     } else if (content.type === 'about') {
       if (ref.isFeed(content.about)) {
         const to = content.about
-        const key = `${from}:${to}`
+        const key = `identify:${from}:${to}`
         actions[key] = 'identified'
       }
     }
@@ -186,7 +186,7 @@ function getActionCounts (actions) {
   // collect who did what and has what done on them
   for (const key in actions) {
     const action = actions[key]
-    const { from, to } = splitKey(key)
+    const [actionType, from, to] = key.split(':')
     actionCounts[from] = actionCounts[from] || { from: {}, to: {} }
     actionCounts[to] = actionCounts[to] || { from: {}, to: {} }
 
@@ -239,12 +239,4 @@ function reduceActions (actionCounts) {
 
 function toggleValue () {
   this.value.set(!this.value())
-}
-
-function splitKey (key) {
-  const mid = key.indexOf(':')
-  return {
-    from: key.slice(0, mid),
-    to: key.slice(mid + 1)
-  }
 }

--- a/lib/depject/message/html/render/following.js
+++ b/lib/depject/message/html/render/following.js
@@ -1,3 +1,4 @@
+const { h } = require('mutant')
 const nest = require('depnest')
 const extend = require('xtend')
 const ref = require('ssb-ref')
@@ -7,6 +8,7 @@ exports.needs = nest({
     decorate: 'reduce',
     layout: 'first'
   },
+  'message.html.markdown': 'first',
   'profile.html.person': 'first',
   'intl.sync.i18n': 'first'
 })
@@ -37,11 +39,16 @@ exports.create = function (api) {
   function messageContent (msg) {
     const following = msg.value.content.following
     const blocking = msg.value.content.blocking
+    const reason = msg.value.content.reason
 
     if (blocking === true) {
-      return [
+      const text = [
         i18n('blocked '), api.profile.html.person(msg.value.content.contact)
       ]
+      if (reason) {
+        text.push(h('section.content', h('Message', api.message.html.markdown(reason))))
+      }
+      return text
     } else if (typeof following === 'boolean') {
       return [
         following ? i18n('followed ') : i18n('unfollowed '),

--- a/lib/depject/message/html/render/following.js
+++ b/lib/depject/message/html/render/following.js
@@ -25,10 +25,19 @@ exports.create = function (api) {
     render: function (msg, opts) {
       if (!isRenderable(msg)) return
 
-      const element = api.message.html.layout(msg, extend({
-        miniContent: messageContent(msg),
-        layout: 'mini'
-      }, opts))
+      const reason = msg.value.content.reason || msg.value.content.comment
+      let element
+      if (msg.value.content.blocking && reason !== undefined && reason !== null) {
+        element = api.message.html.layout(msg, extend({
+          content: messageContentFull(msg),
+          layout: 'default'
+        }, opts))
+      } else {
+        element = api.message.html.layout(msg, extend({
+          miniContent: messageContentMini(msg),
+          layout: 'mini'
+        }, opts))
+      }
 
       return api.message.html.decorate(element, {
         msg
@@ -36,19 +45,37 @@ exports.create = function (api) {
     }
   })
 
-  function messageContent (msg) {
+  function messageContentFull (msg) {
     const following = msg.value.content.following
     const blocking = msg.value.content.blocking
-    const reason = msg.value.content.reason
 
     if (blocking === true) {
-      const text = [
+      const reason = msg.value.content.reason || msg.value.content.comment
+      const blockee = msg.value.content.contact
+      return h('Markdown', [
+        h('div', {}, ['blocked ', h('a', { href: blockee }, api.profile.html.person(blockee))]),
+        h('div', {}, api.message.html.markdown(reason))
+      ])
+    } else if (typeof following === 'boolean') {
+      return [
+        following ? i18n('followed ') : i18n('unfollowed '),
+        api.profile.html.person(msg.value.content.contact)
+      ]
+    } else if (blocking === false) {
+      return [
+        i18n('unblocked '), api.profile.html.person(msg.value.content.contact)
+      ]
+    }
+  }
+
+  function messageContentMini (msg) {
+    const following = msg.value.content.following
+    const blocking = msg.value.content.blocking
+
+    if (blocking === true) {
+      return [
         i18n('blocked '), api.profile.html.person(msg.value.content.contact)
       ]
-      if (reason) {
-        text.push(h('section.content', h('Message', api.message.html.markdown(reason))))
-      }
-      return text
     } else if (typeof following === 'boolean') {
       return [
         following ? i18n('followed ') : i18n('unfollowed '),


### PR DESCRIPTION
This is not beautiful yet, but it already works.
The idea is to render block reasons a full markdown-capable messages like posts. The reasoning being that I don't want to force people to be terse when blocking. (of course they still can be, to the point of not giving a reason)

**Issues:**

The html that this generates doesn't really match that of posts (which also have a different heading) and so it looks bad

Also this reuses the `Message` element and so cannot be styled differently from a normal message. Not sure if we need that though. Frankly I think the messages integrate well if they render exactly like (other) messages. Open for discussion on that though.