### PR TITLE
docs(install): add missing make requirement

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,7 +20,8 @@ apt-get install \
   libxext-dev \
   libxkbfile-dev \
   libxtst-dev \
-  m4
+  m4 \ 
+  make
 ```
 
 ### CentOS / Fedora


### PR DESCRIPTION
Add `make` as requirement for installing/building Patchwork.

Without `make`, the following error is received on a fresh Ubuntu 20.04 install:

```
utson@base:~/patchwork$ npm install

> @felixrieseberg/spellchecker@4.0.12 install /home/hutson/patchwork/node_modules/@felixrieseberg/spellchecker
> node-gyp rebuild

gyp ERR! build error 
gyp ERR! stack Error: not found: make
gyp ERR! stack     at getNotFoundError (/home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/which/which.js:13:12)
gyp ERR! stack     at F (/home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/which/which.js:68:19)
gyp ERR! stack     at E (/home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/which/which.js:80:29)
gyp ERR! stack     at /home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/which/which.js:89:16
gyp ERR! stack     at /home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/isexe/index.js:42:5
gyp ERR! stack     at /home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/isexe/mode.js:8:5
gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:183:21)
gyp ERR! System Linux 5.4.0-60-generic
gyp ERR! command "/home/hutson/.nvm/versions/node/v14.15.4/bin/node" "/home/hutson/.nvm/versions/node/v14.15.4/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/hutson/patchwork/node_modules/@felixrieseberg/spellchecker
gyp ERR! node -v v14.15.4
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @felixrieseberg/spellchecker@4.0.12 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @felixrieseberg/spellchecker@4.0.12 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/hutson/.npm/_logs/2021-01-17T18_03_13_105Z-debug.log
```