### PR TITLE
Update ssb-patchwork version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ssb-patchwork",
-  "version": "3.18.1-beta.2",
+  "version": "3.18.1-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The version number for ssb-patchwork in package-lock.json now matches
package.json. This prevents the repo from being dirty immediately after
running `npm install`.