### PR TITLE
Remove depject, epic 1: shortFeedId

### DIFF
--- a/lib/depject/about/obs.js
+++ b/lib/depject/about/obs.js
@@ -1,3 +1,4 @@
+const shortFeedId = require('./sync.js')
 const { computed } = require('mutant')
 const nest = require('depnest')
 const ref = require('ssb-ref')
@@ -9,7 +10,6 @@ const MutantPullDict = require('../../mutant-pull-dict')
 exports.needs = nest({
   'sbot.pull.stream': 'first',
   'blob.sync.url': 'first',
-  'about.sync.shortFeedId': 'first',
   'keys.sync.id': 'first'
 })
 
@@ -35,7 +35,7 @@ exports.create = function (api) {
   return nest({
     'about.obs': {
       // quick helpers, probably should deprecate!
-      name: (id) => socialValue(id, 'name', api.about.sync.shortFeedId(id)),
+      name: (id) => socialValue(id, 'name', shortFeedId(id)),
       description: (id) => socialValue(id, 'description'),
       image: (id) => socialValue(id, 'image'),
       names: (id) => groupedValues(id, 'name'),

--- a/lib/depject/about/sync.js
+++ b/lib/depject/about/sync.js
@@ -1,9 +1,4 @@
-const nest = require('depnest')
 
-exports.gives = nest('about.sync.shortFeedId')
-
-exports.create = function () {
-  return nest('about.sync.shortFeedId', function (id) {
-    return id.slice(1, 10)
-  })
+module.exports = function (id) {
+  return id.slice(1, 10)
 }

--- a/lib/depject/about/sync/short-feed-id.js
+++ b/lib/depject/about/sync/short-feed-id.js
@@ -1,9 +1,0 @@
-const nest = require('depnest')
-
-exports.gives = nest('about.sync.shortFeedId')
-
-exports.create = function () {
-  return nest('about.sync.shortFeedId', function (id) {
-    return `${id.slice(0, 10)}...`
-  })
-}

--- a/lib/depject/profile/sheet/edit.js
+++ b/lib/depject/profile/sheet/edit.js
@@ -1,3 +1,4 @@
+const shortFeedId = require('../../about/sync.js')
 const nest = require('depnest')
 const extend = require('xtend')
 const { Value, h, computed, when } = require('mutant')
@@ -20,7 +21,6 @@ exports.needs = nest({
   'blob.sync.url': 'first',
   'intl.sync.i18n': 'first',
   'suggest.hook': 'first',
-  'about.sync.shortFeedId': 'first'
 })
 
 exports.create = function (api) {
@@ -36,7 +36,7 @@ exports.create = function (api) {
       const chosenImage = Value(currentImage())
 
       // don't display if name is default
-      const chosenName = Value(currentName() === api.about.sync.shortFeedId(id) ? '' : currentName())
+      const chosenName = Value(currentName() === shortFeedId(id) ? '' : currentName())
       const chosenDescription = Value(currentDescription())
 
       return {


### PR DESCRIPTION
This removes the first file from claws of depject. Well, *my* first file anyhow.
This closes #1371, but *really* it is just the start of an epic battle. :laughing: 

@christianbundy is there any chance you'd remember why there were two near-identical functions with the same name? 
The one I removed added "..." to the end of the shortened feedIds, but it didn't get used anywhere it seems. Was that by accident?
In any case, if some code would want the "..." then I'd say that can be done outside this function. 
Frankly that function might be inlined entirely, but it was a good punching ball for me.