### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Alternatively, you can install Patchwork with your favorite package manager.
 
 - **[npm][npm]:** `npm install --global ssb-patchwork`
 - **[yarn][yarn]:** `yarn global add ssb-patchwork`
-- **[brew][brew]:** `brew cask install patchwork`
+- **[brew][brew]:** `brew install --cask patchwork`
 - **[yay][yay]:** `yay -S ssb-patchwork`
 
 Building from source? Check out [`INSTALL.md`][install] for more information.


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524